### PR TITLE
Pluggable handler for arbitrary relations (see issue #104)

### DIFF
--- a/core/src/main/resources/spline.default.properties
+++ b/core/src/main/resources/spline.default.properties
@@ -33,3 +33,5 @@ spline.iwd_strategy.default.on_missing_metrics=IGNORE_LINEAGE
 # User extra metadata provider
 spline.user_extra_meta_provider.className=za.co.absa.spline.harvester.extra.NoopUserExtraMetaDataProvider
 
+# Proprietary relation support
+spline.read_relation_handler.className=za.co.absa.spline.harvester.builder.read.NoOpReadRelationHandler

--- a/core/src/main/scala/za/co/absa/spline/harvester/LineageHarvester.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/LineageHarvester.scala
@@ -32,7 +32,7 @@ import za.co.absa.spline.harvester.ExtraMetadataImplicits._
 import za.co.absa.spline.harvester.LineageHarvester._
 import za.co.absa.spline.harvester.ModelConstants.{AppMetaInfo, ExecutionEventExtra, ExecutionPlanExtra}
 import za.co.absa.spline.harvester.builder._
-import za.co.absa.spline.harvester.builder.read.ReadCommandExtractor
+import za.co.absa.spline.harvester.builder.read.{ReadCommandExtractor, ReadRelationHandler}
 import za.co.absa.spline.harvester.builder.write.WriteCommandExtractor
 import za.co.absa.spline.harvester.conf.SplineConfigurer.SplineMode
 import za.co.absa.spline.harvester.conf.SplineConfigurer.SplineMode.SplineMode
@@ -49,14 +49,17 @@ class LineageHarvester(
   hadoopConfiguration: Configuration,
   splineMode: SplineMode,
   iwdStrategy: IgnoredWriteDetectionStrategy,
-  userExtraMetadataProvider: UserExtraMetadataProvider
+  userExtraMetadataProvider: UserExtraMetadataProvider,
+  relationHandler: ReadRelationHandler
 ) extends Logging {
 
   private val componentCreatorFactory: ComponentCreatorFactory = new ComponentCreatorFactory
   private val pathQualifier = new HDFSPathQualifier(hadoopConfiguration)
   private val opNodeBuilderFactory = new OperationNodeBuilderFactory(userExtraMetadataProvider, componentCreatorFactory, ctx)
   private val writeCommandExtractor = new WriteCommandExtractor(pathQualifier, ctx.session)
-  private val readCommandExtractor = new ReadCommandExtractor(pathQualifier, ctx.session)
+  private val readCommandExtractor = new ReadCommandExtractor(pathQualifier,
+                                                              ctx.session,
+                                                              relationHandler)
 
   def harvest(result: Try[Duration]): HarvestResult = {
     log.debug(s"Harvesting lineage from ${ctx.logicalPlan.getClass}")

--- a/core/src/main/scala/za/co/absa/spline/harvester/LineageHarvester.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/LineageHarvester.scala
@@ -57,9 +57,7 @@ class LineageHarvester(
   private val pathQualifier = new HDFSPathQualifier(hadoopConfiguration)
   private val opNodeBuilderFactory = new OperationNodeBuilderFactory(userExtraMetadataProvider, componentCreatorFactory, ctx)
   private val writeCommandExtractor = new WriteCommandExtractor(pathQualifier, ctx.session)
-  private val readCommandExtractor = new ReadCommandExtractor(pathQualifier,
-                                                              ctx.session,
-                                                              relationHandler)
+  private val readCommandExtractor = new ReadCommandExtractor(pathQualifier, ctx.session, relationHandler)
 
   def harvest(result: Try[Duration]): HarvestResult = {
     log.debug(s"Harvesting lineage from ${ctx.logicalPlan.getClass}")

--- a/core/src/main/scala/za/co/absa/spline/harvester/LineageHarvesterFactory.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/LineageHarvesterFactory.scala
@@ -19,6 +19,7 @@ package za.co.absa.spline.harvester
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.SparkPlan
+import za.co.absa.spline.harvester.builder.read.ReadRelationHandler
 import za.co.absa.spline.harvester.conf.SplineConfigurer.SplineMode.SplineMode
 import za.co.absa.spline.harvester.extra.UserExtraMetadataProvider
 import za.co.absa.spline.harvester.iwd.IgnoredWriteDetectionStrategy
@@ -28,7 +29,8 @@ import scala.language.postfixOps
 class LineageHarvesterFactory(
   splineMode: SplineMode,
   iwdStrategy: IgnoredWriteDetectionStrategy,
-  userExtraMetadataProvider: UserExtraMetadataProvider) {
+  userExtraMetadataProvider: UserExtraMetadataProvider,
+  relationHandler: ReadRelationHandler) {
 
   def harvester(logicalPlan: LogicalPlan, executedPlan: Option[SparkPlan], session: SparkSession): LineageHarvester =
     new LineageHarvester(
@@ -36,6 +38,7 @@ class LineageHarvesterFactory(
       session.sparkContext.hadoopConfiguration,
       splineMode,
       iwdStrategy,
-      userExtraMetadataProvider
+      userExtraMetadataProvider,
+      relationHandler
     )
 }

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/read/NoOpReadRelationHandler.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/read/NoOpReadRelationHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 ABSA Group Limited
+ * Copyright 2020 ABSA Group Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/read/NoOpReadRelationHandler.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/read/NoOpReadRelationHandler.scala
@@ -35,8 +35,7 @@ class NoOpReadRelationHandler(config: Configuration) extends ReadRelationHandler
   /**
    * Unconditionally throws an [[UnsupportedOperationException]].
    */
-  override def apply(relation: BaseRelation,
-                     logicalPlan: LogicalPlan): ReadCommand =
+  override def apply(relation: BaseRelation, logicalPlan: LogicalPlan): ReadCommand =
     throw new UnsupportedOperationException("NoOpRelationHandler - use isApplicable to avoid this exception")
 }
 

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/read/NoOpReadRelationHandler.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/read/NoOpReadRelationHandler.scala
@@ -1,0 +1,28 @@
+package za.co.absa.spline.harvester.builder.read
+import org.apache.commons.configuration.{BaseConfiguration, Configuration}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.sources.BaseRelation
+
+/**
+ * No-op [[ReadRelationHandler]], isApplicable always returns false.
+ */
+class NoOpReadRelationHandler(config: Configuration) extends ReadRelationHandler {
+  /**
+   * Determine if the relation can be processed by implementing classes.
+   *
+   * @param relation the relation to process
+   * @return true iff the implementing class can process this relation
+   */
+  override def isApplicable(relation: BaseRelation): Boolean = false
+
+  /**
+   * Unconditionally throws an [[UnsupportedOperationException]].
+   */
+  override def apply(relation: BaseRelation,
+                     logicalPlan: LogicalPlan): ReadCommand =
+    throw new UnsupportedOperationException("NoOpRelationHandler - use isApplicable to avoid this exception")
+}
+
+object NoOpReadRelationHandler {
+  def apply(): ReadRelationHandler = new NoOpReadRelationHandler(new BaseConfiguration)
+}

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/read/NoOpReadRelationHandler.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/read/NoOpReadRelationHandler.scala
@@ -1,4 +1,21 @@
+/*
+ * Copyright 2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package za.co.absa.spline.harvester.builder.read
+
 import org.apache.commons.configuration.{BaseConfiguration, Configuration}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.sources.BaseRelation

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/read/ReadCommandExtractor.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/read/ReadCommandExtractor.scala
@@ -131,8 +131,7 @@ class ReadCommandExtractor(
 
         case br: BaseRelation =>
           if (relationHandler.isApplicable(br)) {
-            relationHandler(br,
-                            operation)
+            relationHandler(br, operation)
           } else {
             sys.error(s"Relation is not supported: $br")
           }

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/read/ReadCommandExtractor.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/read/ReadCommandExtractor.scala
@@ -43,9 +43,11 @@ import scala.collection.JavaConverters._
 import scala.util.Try
 
 
-class ReadCommandExtractor(pathQualifier: PathQualifier,
-                           session: SparkSession,
-                           relationHandler: ReadRelationHandler) {
+class ReadCommandExtractor(
+  pathQualifier: PathQualifier,
+  session: SparkSession,
+  relationHandler: ReadRelationHandler) {
+
   def asReadCommand(operation: LogicalPlan): Option[ReadCommand] =
     condOpt(operation) {
       case lr: LogicalRelation => lr.relation match {

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/read/ReadCommandExtractor.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/read/ReadCommandExtractor.scala
@@ -45,7 +45,7 @@ import scala.util.Try
 
 class ReadCommandExtractor(pathQualifier: PathQualifier,
                            session: SparkSession,
-                           relationHandler: ReadRelationHandler = NoOpReadRelationHandler()) {
+                           relationHandler: ReadRelationHandler) {
   def asReadCommand(operation: LogicalPlan): Option[ReadCommand] =
     condOpt(operation) {
       case lr: LogicalRelation => lr.relation match {

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/read/ReadCommandExtractor.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/read/ReadCommandExtractor.scala
@@ -43,7 +43,9 @@ import scala.collection.JavaConverters._
 import scala.util.Try
 
 
-class ReadCommandExtractor(pathQualifier: PathQualifier, session: SparkSession) {
+class ReadCommandExtractor(pathQualifier: PathQualifier,
+                           session: SparkSession,
+                           relationHandler: ReadRelationHandler = NoOpReadRelationHandler()) {
   def asReadCommand(operation: LogicalPlan): Option[ReadCommand] =
     condOpt(operation) {
       case lr: LogicalRelation => lr.relation match {
@@ -126,7 +128,12 @@ class ReadCommandExtractor(pathQualifier: PathQualifier, session: SparkSession) 
           ReadCommand(SourceIdentifier.forCobrix(sourceDir), operation)
 
         case br: BaseRelation =>
-          sys.error(s"Relation is not supported: $br")
+          if (relationHandler.isApplicable(br)) {
+            relationHandler(br,
+                            operation)
+          } else {
+            sys.error(s"Relation is not supported: $br")
+          }
       }
 
       case htr: HiveTableRelation =>

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/read/ReadRelationHandler.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/read/ReadRelationHandler.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.spline.harvester.builder.read
+
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.sources.BaseRelation
+
+/**
+ * Extension point for dealing with [[BaseRelation]] instances not
+ * already handled within Spline.
+ *
+ * Implementations of this trait should have a constructor that takes a
+ * [[org.apache.commons.configuration.Configuration]] as a parameter.
+ */
+trait ReadRelationHandler extends ((BaseRelation, LogicalPlan) => ReadCommand)  {
+
+  /**
+   * Determine if the relation can be processed by implementing classes.
+   *
+   * @param relation the relation to process
+   * @return true iff the implementing class can process this relation
+   */
+  def isApplicable(relation: BaseRelation): Boolean
+
+  /**
+   * Process the relation in some arbitrary fashion.
+   *
+   * @param relation the relation to process
+   * @param logicalPlan the plan associated with the relation
+   * @return a [[ReadCommand]]
+   */
+  def apply(relation: BaseRelation,
+            logicalPlan: LogicalPlan): ReadCommand
+}

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/read/ReadRelationHandler.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/read/ReadRelationHandler.scala
@@ -43,6 +43,5 @@ trait ReadRelationHandler extends ((BaseRelation, LogicalPlan) => ReadCommand)  
    * @param logicalPlan the plan associated with the relation
    * @return a [[ReadCommand]]
    */
-  def apply(relation: BaseRelation,
-            logicalPlan: LogicalPlan): ReadCommand
+  def apply(relation: BaseRelation, logicalPlan: LogicalPlan): ReadCommand
 }

--- a/core/src/main/scala/za/co/absa/spline/harvester/conf/DefaultSplineConfigurer.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/conf/DefaultSplineConfigurer.scala
@@ -22,6 +22,7 @@ import org.apache.commons.configuration.{CompositeConfiguration, Configuration, 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import za.co.absa.commons.config.ConfigurationImplicits
+import za.co.absa.spline.harvester.builder.read.ReadRelationHandler
 import za.co.absa.spline.harvester.conf.SplineConfigurer.SplineMode
 import za.co.absa.spline.harvester.dispatcher.LineageDispatcher
 import za.co.absa.spline.harvester.extra.UserExtraMetadataProvider
@@ -46,6 +47,11 @@ object DefaultSplineConfigurer {
      * Lineage dispatcher used to report lineages
      */
     val LineageDispatcherClass = "spline.lineage_dispatcher.className"
+
+    /**
+     * Relation handler used to deal with proprietary relations
+     */
+    val RelationHandlerClass = "spline.read_relation_handler.className"
 
     /**
      * Strategy used to detect ignored writes
@@ -91,6 +97,10 @@ class DefaultSplineConfigurer(userConfiguration: Configuration)
   override def queryExecutionEventHandler: QueryExecutionEventHandler =
     new QueryExecutionEventHandler(harvesterFactory, lineageDispatcher)
 
+  protected def relationHandler: ReadRelationHandler = instantiate[ReadRelationHandler](
+    configuration.getString(RelationHandlerClass,
+                            "za.co.absa.spline.harvester.builder.read.NoOpReadRelationHandler"))
+
   protected def lineageDispatcher: LineageDispatcher = instantiate[LineageDispatcher](
     configuration.getRequiredString(LineageDispatcherClass))
 
@@ -103,7 +113,8 @@ class DefaultSplineConfigurer(userConfiguration: Configuration)
   private def harvesterFactory = new LineageHarvesterFactory(
     splineMode,
     ignoredWriteDetectionStrategy,
-    userExtraMetadataProvider)
+    userExtraMetadataProvider,
+    relationHandler)
 
   private def instantiate[T: ClassTag](className: String): T = {
     val interfaceName = scala.reflect.classTag[T].runtimeClass.getSimpleName

--- a/core/src/main/scala/za/co/absa/spline/harvester/conf/DefaultSplineConfigurer.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/conf/DefaultSplineConfigurer.scala
@@ -69,9 +69,7 @@ object DefaultSplineConfigurer {
   }
 }
 
-class DefaultSplineConfigurer(userConfiguration: Configuration)
-  extends SplineConfigurer
-    with Logging {
+class DefaultSplineConfigurer(userConfiguration: Configuration) extends SplineConfigurer with Logging {
 
   import ConfigurationImplicits._
   import DefaultSplineConfigurer.ConfProperty._
@@ -98,8 +96,9 @@ class DefaultSplineConfigurer(userConfiguration: Configuration)
     new QueryExecutionEventHandler(harvesterFactory, lineageDispatcher)
 
   protected def relationHandler: ReadRelationHandler = instantiate[ReadRelationHandler](
-    configuration.getString(RelationHandlerClass,
-                            "za.co.absa.spline.harvester.builder.read.NoOpReadRelationHandler"))
+    configuration.getString(
+      RelationHandlerClass,
+      "za.co.absa.spline.harvester.builder.read.NoOpReadRelationHandler"))
 
   protected def lineageDispatcher: LineageDispatcher = instantiate[LineageDispatcher](
     configuration.getRequiredString(LineageDispatcherClass))

--- a/core/src/test/scala/za/co/absa/spline/harvester/builder/read/NoOpReadRelationHandlerSpec.scala
+++ b/core/src/test/scala/za/co/absa/spline/harvester/builder/read/NoOpReadRelationHandlerSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package za.co.absa.spline.harvester.builder.read
 
 import com.databricks.spark.xml.XmlRelation

--- a/core/src/test/scala/za/co/absa/spline/harvester/builder/read/NoOpReadRelationHandlerSpec.scala
+++ b/core/src/test/scala/za/co/absa/spline/harvester/builder/read/NoOpReadRelationHandlerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 ABSA Group Limited
+ * Copyright 2020 ABSA Group Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,8 +34,8 @@ class NoOpReadRelationHandlerSpec extends AnyFlatSpec with Matchers with Mockito
   }
 
   it should "throw an exception if applied" in {
-    val operationFailed: Boolean = Try(NoOpReadRelationHandler().apply(mock[BaseRelation],
-                                                                           mock[LogicalPlan])) match {
+    val tryApplyingMocks = Try(NoOpReadRelationHandler().apply(mock[BaseRelation], mock[LogicalPlan]))
+    val operationFailed: Boolean = tryApplyingMocks match {
       case _: Failure[_] => true
       case _ => false
     }

--- a/core/src/test/scala/za/co/absa/spline/harvester/builder/read/NoOpReadRelationHandlerSpec.scala
+++ b/core/src/test/scala/za/co/absa/spline/harvester/builder/read/NoOpReadRelationHandlerSpec.scala
@@ -25,9 +25,7 @@ import org.scalatestplus.mockito.MockitoSugar
 
 import scala.util.{Failure, Try}
 
-class NoOpReadRelationHandlerSpec extends AnyFlatSpec
-                                          with Matchers
-                                          with MockitoSugar {
+class NoOpReadRelationHandlerSpec extends AnyFlatSpec with Matchers with MockitoSugar {
 
   it should "unconditionally return false for isApplicable" in {
     val handler: ReadRelationHandler = NoOpReadRelationHandler()

--- a/core/src/test/scala/za/co/absa/spline/harvester/builder/read/NoOpReadRelationHandlerSpec.scala
+++ b/core/src/test/scala/za/co/absa/spline/harvester/builder/read/NoOpReadRelationHandlerSpec.scala
@@ -1,0 +1,30 @@
+package za.co.absa.spline.harvester.builder.read
+
+import com.databricks.spark.xml.XmlRelation
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.sources.BaseRelation
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+
+import scala.util.{Failure, Try}
+
+class NoOpReadRelationHandlerSpec extends AnyFlatSpec
+                                          with Matchers
+                                          with MockitoSugar {
+
+  it should "unconditionally return false for isApplicable" in {
+    val handler: ReadRelationHandler = NoOpReadRelationHandler()
+    handler.isApplicable(mock[BaseRelation]) mustBe false
+    handler.isApplicable(mock[XmlRelation]) mustBe false
+  }
+
+  it should "throw an exception if applied" in {
+    val operationFailed: Boolean = Try(NoOpReadRelationHandler().apply(mock[BaseRelation],
+                                                                           mock[LogicalPlan])) match {
+      case _: Failure[_] => true
+      case _ => false
+    }
+    operationFailed mustBe true
+  }
+}

--- a/core/src/test/scala/za/co/absa/spline/harvester/builder/read/ReadCommandExtractorSpec.scala
+++ b/core/src/test/scala/za/co/absa/spline/harvester/builder/read/ReadCommandExtractorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 ABSA Group Limited
+ * Copyright 2020 ABSA Group Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package za.co.absa.spline.harvester.builder.read
 
 import org.apache.hadoop.conf.Configuration
-import org.apache.spark.SPARK_VERSION
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.datasources.LogicalRelation
@@ -42,16 +41,13 @@ class ReadCommandExtractorSpec extends AnyFlatSpec with Matchers with SparkTestB
     object TestRelationHandler extends ReadRelationHandler {
       override def isApplicable(relation: BaseRelation): Boolean = relation.isInstanceOf[TestRelation]
 
-      override def apply(relation: BaseRelation,
-                         logicalPlan: LogicalPlan): ReadCommand =
+      override def apply(relation: BaseRelation, logicalPlan: LogicalPlan): ReadCommand =
         ReadCommand(SourceIdentifier(Some("test")), logicalPlan)
     }
 
     val result: Option[ReadCommand] =
-      new ReadCommandExtractor(pathQualifier,
-                               spark,
-                               TestRelationHandler)
-        .asReadCommand(logicalPlan)
+      new ReadCommandExtractor(pathQualifier, spark, TestRelationHandler).asReadCommand(logicalPlan)
+
     result.isDefined mustBe true
     result.map(rc => rc.sourceIdentifier).flatMap(si => si.format).getOrElse("fail") mustBe "test"
   }

--- a/core/src/test/scala/za/co/absa/spline/harvester/builder/read/ReadCommandExtractorSpec.scala
+++ b/core/src/test/scala/za/co/absa/spline/harvester/builder/read/ReadCommandExtractorSpec.scala
@@ -1,0 +1,65 @@
+package za.co.absa.spline.harvester.builder.read
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.{LeafNode, LogicalPlan, Statistics}
+import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.sources.BaseRelation
+import org.apache.spark.sql.types.StructType
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+import za.co.absa.commons.spark.SparkTestBase
+import za.co.absa.spline.harvester.builder.SourceIdentifier
+import za.co.absa.spline.harvester.qualifier.HDFSPathQualifier
+
+import scala.util.{Failure, Try}
+
+class ReadCommandExtractorSpec extends AnyFlatSpec
+                                       with Matchers
+                                       with SparkTestBase
+                                       with MockitoSugar {
+
+  private val conf = new Configuration()
+  private val pathQualifier = new HDFSPathQualifier(conf)
+
+  it must "defer to the relation handler if there is a compatible one" in {
+    val logicalPlan: TestLogicalPlan = new TestLogicalPlan(TestRelation(spark.sqlContext))
+    object TestRelationHandler extends ReadRelationHandler {
+      override def isApplicable(relation: BaseRelation): Boolean = relation.isInstanceOf[TestRelation]
+
+      override def apply(relation: BaseRelation,
+                         logicalPlan: LogicalPlan): ReadCommand = ReadCommand(SourceIdentifier(Some("test")),
+                                                                              logicalPlan)
+    }
+
+    val result: Option[ReadCommand] = new ReadCommandExtractor(pathQualifier,
+                                                               spark,
+                                                               TestRelationHandler)
+      .asReadCommand(logicalPlan)
+    result.isDefined mustBe true
+    result.map(rc => rc.sourceIdentifier).flatMap(si => si.format).getOrElse("fail") mustBe "test"
+  }
+
+  it must "return a None if there is no way to handle the relation" in {
+    val relationNotHandled: Boolean = Try(new ReadCommandExtractor(pathQualifier,
+                                                                   spark)
+                                            .asReadCommand(new TestLogicalPlan(TestRelation(spark.sqlContext)))) match {
+      case _: Failure[_] => true
+      case _ => false
+    }
+    relationNotHandled mustBe true
+  }
+}
+
+private case class TestRelation(sqlCxt: SQLContext) extends BaseRelation {
+  override def sqlContext: SQLContext = sqlCxt
+
+  override def schema: StructType = StructType(Seq.empty)
+}
+
+private class TestLogicalPlan(delegate: BaseRelation) extends LogicalRelation(delegate,
+                                                                              Seq.empty,
+                                                                              None,
+                                                                              false)

--- a/examples/src/main/resources/spline.properties
+++ b/examples/src/main/resources/spline.properties
@@ -27,3 +27,4 @@
 #
 # spline.mode=DISABLED|REQUIRED|BEST_EFFORT
 # spline.producer.url=http://localhost:8080/spline/producer
+# spline.read_relation_handler.className=za.co.absa.spline.harvester.builder.read.NoOpReadRelationHandler


### PR DESCRIPTION
This change adds support for pluggable relation handling in ReadCommandExtractor.  The default handler is no-op and results in no changes to existing behaviour.

If the  spline.read_relation_handler.className property is set, the specified implementation of za.co.absa.spline.harvester.builder.read.ReadRelationHandler will be instantiated.  Implementations require a constructor that takes a org.apache.commons.configuration.Configuration