### PR TITLE
Move binary expression "symbol" property from params to extras

### DIFF
--- a/core/src/main/scala/za/co/absa/spline/harvester/converter/ExpressionConverter.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/converter/ExpressionConverter.scala
@@ -54,9 +54,9 @@ class ExpressionConverter(
         id = randomUUIDString,
         dataType = convertDataType(bo),
         childIds = convertChildren(bo).asOption,
-        extra = createExtra(bo, "expr.Binary").asOption,
+        extra = (createExtra(bo, "expr.Binary") + ("symbol" -> bo.symbol)).asOption,
         name = bo.prettyName,
-        params = (getExpressionParameters(bo) + ("symbol" -> bo.symbol)).asOption
+        params = getExpressionParameters(bo).asOption
       )
 
     case u: sparkExprssions.ScalaUDF =>


### PR DESCRIPTION
The "params" are supposed to contain stuff that affects the expression output in any way (e.g. tuning parameters, number formats etc). The "symbol" being a static representational property (an alias to the "name") fits extras better.