### PR TITLE
#185 - windows build fix. 

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -134,7 +134,7 @@
             <plugin>
                 <groupId>io.swagger.codegen.v3</groupId>
                 <artifactId>swagger-codegen-maven-plugin</artifactId>
-                <version>3.0.21</version>
+                <version>3.0.21</version> <!-- please note 3.0.22+ were problematic on Windows. See Issue #185 -->
                 <configuration>
                     <language>scala</language>
                     <generateModels>true</generateModels>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -134,7 +134,7 @@
             <plugin>
                 <groupId>io.swagger.codegen.v3</groupId>
                 <artifactId>swagger-codegen-maven-plugin</artifactId>
-                <version>3.0.23</version>
+                <version>3.0.21</version>
                 <configuration>
                     <language>scala</language>
                     <generateModels>true</generateModels>

--- a/core/src/main/scala/za/co/absa/spline/harvester/converter/AttributeConverter.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/converter/AttributeConverter.scala
@@ -40,6 +40,7 @@ class AttributeConverter(
         dataType = Some(dataTypeConverter.convert(attr.dataType, attr.nullable).id),
         childIds = resolveAttributeChild(attr)
           .map(expr => Seq(exprToRefConverter.convert(expr))),
+        extra = None,
         name = attr.name
       )
   }

--- a/core/src/test/scala/za/co/absa/spline/harvester/dispatcher/ConsoleLineageDispatcherSpec.scala
+++ b/core/src/test/scala/za/co/absa/spline/harvester/dispatcher/ConsoleLineageDispatcherSpec.scala
@@ -33,7 +33,7 @@ class ConsoleLineageDispatcherSpec
     assertingStdOut(include("""["event",{"planId":null,"timestamp":999}]""")) {
       new ConsoleLineageDispatcher(new BaseConfiguration {
         addProperty("stream", "OUT")
-      }).send(ExecutionEvent(null, 999))
+      }).send(ExecutionEvent(null, 999, None, None))
     }
   }
 
@@ -41,7 +41,7 @@ class ConsoleLineageDispatcherSpec
     assertingStdErr(include("""["event",{"planId":null,"timestamp":999}]""")) {
       new ConsoleLineageDispatcher(new BaseConfiguration {
         addProperty("stream", "ERR")
-      }).send(ExecutionEvent(null, 999))
+      }).send(ExecutionEvent(null, 999, None, None))
     }
   }
 


### PR DESCRIPTION
 - Mainly, downgrading swagger codegen to 3.0.21 from 3.0.23 (src: https://www.gitmemory.com/issue/swagger-api/swagger-codegen/10844/764741128)
 - other small fields generation fixes (usage did not match the generated case classes)

Closes #185 