### PR TITLE
Bugfix/spline spark agent 188 spark session wrapper

### DIFF
--- a/bundle-2.2/pom.xml
+++ b/bundle-2.2/pom.xml
@@ -1088,6 +1088,16 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.spurint.maven.plugins</groupId>
+                <artifactId>mima-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>check-abi</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>com.github.cerveada</groupId>
                 <artifactId>scalatest-maven-plugin</artifactId>
                 <configuration>

--- a/bundle-2.3/pom.xml
+++ b/bundle-2.3/pom.xml
@@ -1178,6 +1178,16 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.spurint.maven.plugins</groupId>
+                <artifactId>mima-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>check-abi</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>com.github.cerveada</groupId>
                 <artifactId>scalatest-maven-plugin</artifactId>
                 <configuration>

--- a/bundle-2.4/pom.xml
+++ b/bundle-2.4/pom.xml
@@ -1168,6 +1168,16 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.spurint.maven.plugins</groupId>
+                <artifactId>mima-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>check-abi</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>com.github.cerveada</groupId>
                 <artifactId>scalatest-maven-plugin</artifactId>
                 <configuration>

--- a/integration-tests/src/test/scala/za/co/absa/spline/harvester/dispatcher/HDFSLineageDispatcherSpec.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/harvester/dispatcher/HDFSLineageDispatcherSpec.scala
@@ -24,7 +24,7 @@ import za.co.absa.commons.io.TempDirectory
 import za.co.absa.commons.json.DefaultJacksonJsonSerDe
 import za.co.absa.commons.scalatest.ConditionalTestTags.ignoreIf
 import za.co.absa.commons.version.Version._
-import za.co.absa.spline.harvester.SparkLineageInitializer.SparkSessionWrapper
+import za.co.absa.spline.harvester.SparkLineageInitializer._
 import za.co.absa.spline.test.fixture.SparkFixture
 
 import java.io.File

--- a/pom.xml
+++ b/pom.xml
@@ -260,6 +260,11 @@
                     <artifactId>maven-antrun-plugin</artifactId>
                     <version>1.8</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.spurint.maven.plugins</groupId>
+                    <artifactId>mima-maven-plugin</artifactId>
+                    <version>0.8.0</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
@@ -661,6 +666,28 @@
                                 <version>5.5.1.201910021850-r</version>
                             </dependency>
                         </dependencies>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <!-- Binary compatibility checking profile -->
+
+        <profile>
+            <id>binary-compat-check</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.spurint.maven.plugins</groupId>
+                        <artifactId>mima-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>check-abi</id>
+                                <goals>
+                                    <goal>check-abi</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
- Rename `SparkSessionWrapper` to `SplineSparkSessionWrapper`
- Reversed delegation between `SplineSparkSessionWrapper` and `SparkLineageInitializer` (the later is now primary class, and the wrapper delegates to it)
- Improved the Scala doc.
- Added `MiMa` Maven plugin for binary compatibility checking between releases