### PR TITLE
spline #200 Remove `NoEmptyValueSupport`

### DIFF
--- a/core/src/main/scala/za/co/absa/spline/harvester/json/HarvesterJsonSerDe.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/json/HarvesterJsonSerDe.scala
@@ -36,7 +36,6 @@ object HarvesterJsonSerDe {
       new AbstractJsonSerDe[JValue]
         with JsonMethods
         with ShortTypeHintForSpline03ModelSupport
-        with NoEmptyValuesSupport
         with JavaTypesSupport
     """)(Map.empty)
 }

--- a/core/src/test/scala/za/co/absa/spline/harvester/dispatcher/ConsoleLineageDispatcherSpec.scala
+++ b/core/src/test/scala/za/co/absa/spline/harvester/dispatcher/ConsoleLineageDispatcherSpec.scala
@@ -33,15 +33,7 @@ class ConsoleLineageDispatcherSpec
 
   private val uuid1 = UUID.fromString("12345678-90ab-cdef-1234-567890abcdef")
 
-  it should "send lineage to the stdout (null planId)" in {
-    assertingStdOut(include("""["event",{"timestamp":999}]""")) {
-      new ConsoleLineageDispatcher(new BaseConfiguration {
-        addProperty("stream", "OUT")
-      }).send(ExecutionEvent(null, 999, None, None, None))
-    }
-  }
-
-  it should "send lineage to the stdout (non-null planId)" in {
+  it should "send lineage to the stdout" in {
     assertingStdOut(include("""["event",{"planId":"12345678-90ab-cdef-1234-567890abcdef","timestamp":999}]""")) {
       new ConsoleLineageDispatcher(new BaseConfiguration {
         addProperty("stream", "OUT")
@@ -49,15 +41,7 @@ class ConsoleLineageDispatcherSpec
     }
   }
 
-  it should "send lineage to the stderr (null planId)" in {
-    assertingStdErr(include("""["event",{"timestamp":999}]""")) {
-      new ConsoleLineageDispatcher(new BaseConfiguration {
-        addProperty("stream", "ERR")
-      }).send(ExecutionEvent(null, 999, None, None, None))
-    }
-  }
-
-  it should "send lineage to the stderr (non-null planId)" in {
+  it should "send lineage to the stderr" in {
     assertingStdErr(include("""["event",{"planId":"12345678-90ab-cdef-1234-567890abcdef","timestamp":999}]""")) {
       new ConsoleLineageDispatcher(new BaseConfiguration {
         addProperty("stream", "ERR")

--- a/core/src/test/scala/za/co/absa/spline/harvester/json/HarvesterJsonSerDeSpec.scala
+++ b/core/src/test/scala/za/co/absa/spline/harvester/json/HarvesterJsonSerDeSpec.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.spline.harvester.json
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import za.co.absa.spline.harvester.json.HarvesterJsonSerDeSpec.Foo
+
+class HarvesterJsonSerDeSpec
+  extends AnyFlatSpec
+    with Matchers {
+
+  import HarvesterJsonSerDe.impl._
+
+  behavior of "HarvesterJsonSerDe"
+
+  it should "eliminate Nones, but preserve empty strings and empty collections" in {
+    Foo(
+      opt = None,
+      str = "",
+      seq = Seq.empty,
+      map = Map.empty
+    ).toJson.fromJson[Map[String, Any]] should equal(
+      Map(
+        // "opt" -> should be missing
+        "str" -> "",
+        "seq" -> Seq.empty,
+        "map" -> Map.empty
+      ))
+  }
+
+  it should "preserve nulls" in {
+    Foo(
+      opt = null,
+      str = null,
+      seq = null,
+      map = null
+    ).toJson.fromJson[Map[String, Any]] should equal(
+      Map(
+        "opt" -> null,
+        "str" -> null,
+        "seq" -> null,
+        "map" -> null
+      ))
+  }
+}
+
+object HarvesterJsonSerDeSpec {
+
+  case class Foo(
+    str: String,
+    opt: Option[Any],
+    seq: Seq[Int],
+    map: Map[String, Any]
+  )
+
+}


### PR DESCRIPTION
Fixes missing `null` values in required places.
This trait seems to be redundant anyway