### PR TITLE
spline #spline-spark-agent-187 POM: Enable Examples docker image publ…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,9 @@
 # limitations under the License.
 #
 
-FROM maven:3.6.3-openjdk-8
+ARG DOCKER_BASE_IMAGE_PREFIX=
+
+FROM "$DOCKER_BASE_IMAGE_PREFIX"maven:3.6.3-openjdk-8
 
 LABEL \
     vendor="ABSA" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,12 +15,24 @@
 #
 
 FROM maven:3.6.3-openjdk-8
+
+LABEL \
+    vendor="ABSA" \
+    copyright="2021 ABSA Group Limited" \
+    license="Apache License, version 2.0" \
+    name="Spline Agent for Apache Spark - Example suite"
+
 COPY . /opt/spline-spark-agent
 
-ENV SPLINE_PRODUCER_URL=http://spline.spline:8080/producer
+ENV SPLINE_PRODUCER_URL=http://host.docker.internal:8080/producer
+ENV SPLINE_MODE=REQUIRED
+
+ENV HTTP_PROXY_HOST=
+ENV HTTP_PROXY_PORT=
+ENV HTTP_NON_PROXY_HOSTS=
 
 RUN cd /opt/spline-spark-agent && \
-    mvn install -DskipTests && \
+    mvn install -D skipTests && \
     cd ./examples && \
     # it's for dry-run maven caching
     mvn test -P examples -D spline.mode=DISABLED
@@ -29,4 +41,9 @@ ENV WORKDIR=/opt/spline-spark-agent/examples
 
 WORKDIR $WORKDIR
 
-CMD mvn test -P examples -D spline.producer.url=$SPLINE_PRODUCER_URL 
+CMD mvn test -P examples \
+    -D spline.producer.url=$SPLINE_PRODUCER_URL \
+    -D spline.mode=$SPLINE_MODE \
+    -D http.proxyHost=$HTTP_PROXY_HOST \
+    -D http.proxyPort=$HTTP_PROXY_PORT \
+    -D http.nonProxyHosts=$HTTP_NON_PROXY_HOSTS \

--- a/bundle-2.2/pom.xml
+++ b/bundle-2.2/pom.xml
@@ -1116,6 +1116,13 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/bundle-2.3/pom.xml
+++ b/bundle-2.3/pom.xml
@@ -1206,6 +1206,13 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/bundle-2.4/pom.xml
+++ b/bundle-2.4/pom.xml
@@ -1196,6 +1196,13 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/bundle-3.0/pom.xml
+++ b/bundle-3.0/pom.xml
@@ -1291,6 +1291,13 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -208,6 +208,13 @@
                 <groupId>com.github.cerveada</groupId>
                 <artifactId>scalatest-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -57,6 +57,19 @@
             <artifactId>kafka-clients</artifactId>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <profiles>
         <profile>
             <id>license-check</id>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -184,6 +184,13 @@
                     </excludes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,9 @@
         <dockerfile.imageName><!-- defined in submodules --></dockerfile.imageName>
         <!-- Either ${dockerfile.repositoryUrl} or ${dockerfile.repositoryUrl} is required to be explicitly provided in the `mvn` command -->
         <dockerfile.repositoryUrl><!-- defined externally --></dockerfile.repositoryUrl>
-        <dockerfile.repository>${dockerfile.repositoryUrl}/${dockerfile.imageName}</dockerfile.repository>
+        <dockerfile.repositoryPrefix>${dockerfile.repositoryUrl}/</dockerfile.repositoryPrefix>
+        <dockerfile.repositorySuffix><!-- defined externally --></dockerfile.repositorySuffix>
+        <dockerfile.repository>${dockerfile.repositoryPrefix}${dockerfile.imageName}${dockerfile.repositorySuffix}</dockerfile.repository>
         <!-- [Optional] The prefix for the base images in Dockerfile (mainly used in custom CI/CD pipelines to pull images from alternative locations) -->
         <dockerfile.baseImagePrefix><!-- defined externally --></dockerfile.baseImagePrefix>
 

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,8 @@
         <scm.connection>scm:git:git://github.com/AbsaOSS/spline-spark-agent.git</scm.connection>
         <scm.developerConnection>scm:git:ssh://github.com/AbsaOSS/spline-spark-agent.git</scm.developerConnection>
 
+        <dockerfile.repositoryUrl><!-- defined externally --></dockerfile.repositoryUrl>
+
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
         <slf4j.version>1.7.25</slf4j.version>
@@ -265,6 +267,11 @@
                     <groupId>org.spurint.maven.plugins</groupId>
                     <artifactId>mima-maven-plugin</artifactId>
                     <version>0.8.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>com.spotify</groupId>
+                    <artifactId>dockerfile-maven-plugin</artifactId>
+                    <version>1.4.13</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -641,6 +648,43 @@
                             <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                             <autoReleaseAfterClose>true</autoReleaseAfterClose>
                             <autoDropAfterRelease>true</autoDropAfterRelease>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>docker</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.spotify</groupId>
+                        <artifactId>dockerfile-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>tag-version</id>
+                                <goals>
+                                    <goal>build</goal>
+                                    <goal>push</goal>
+                                </goals>
+                                <configuration>
+                                    <tag>${project.version}</tag>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>tag-latest</id>
+                                <goals>
+                                    <goal>tag</goal>
+                                    <goal>push</goal>
+                                </goals>
+                                <configuration>
+                                    <tag>latest</tag>
+                                </configuration>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <repository>${dockerfile.repositoryUrl}/spline-spark-agent</repository>
+                            <useMavenSettingsForAuth>true</useMavenSettingsForAuth>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,11 @@
         <dockerfile.latestTagName>${dockerfile.latestTagPrefix}latest${dockerfile.latestTagSuffix}</dockerfile.latestTagName>
 
         <dockerfile.imageName><!-- defined in submodules --></dockerfile.imageName>
-        <!-- Either ${dockerfile.repositoryUrl} or ${dockerfile.repositoryUrl} is required to be explicitly provided in the `mvn` command -->
+        <!--
+            One of `dockerfile.repositoryUrl`, `dockerfile.repositoryPrefix` or `dockerfile.repository`
+            properties is required to be explicitly provided in the `mvn` command,
+            so that the resulted `dockerfile.repository` property has a correct value.
+        -->
         <dockerfile.repositoryUrl><!-- defined externally --></dockerfile.repositoryUrl>
         <dockerfile.repositoryPrefix>${dockerfile.repositoryUrl}/</dockerfile.repositoryPrefix>
         <dockerfile.repositorySuffix><!-- defined externally --></dockerfile.repositorySuffix>

--- a/pom.xml
+++ b/pom.xml
@@ -70,11 +70,28 @@
         <scm.connection>scm:git:git://github.com/AbsaOSS/spline-spark-agent.git</scm.connection>
         <scm.developerConnection>scm:git:ssh://github.com/AbsaOSS/spline-spark-agent.git</scm.developerConnection>
 
-        <dockerfile.repositoryUrl><!-- defined externally --></dockerfile.repositoryUrl>
-
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
         <slf4j.version>1.7.25</slf4j.version>
+
+        <!-- Docker -->
+
+        <dockerfile.imageName>spline-spark-agent</dockerfile.imageName>
+
+        <dockerfile.versionTagPrefix><!-- defined externally --></dockerfile.versionTagPrefix>
+        <dockerfile.versionTagSuffix><!-- defined externally --></dockerfile.versionTagSuffix>
+        <dockerfile.versionTagName>${dockerfile.versionTagPrefix}${project.version}${dockerfile.versionTagSuffix}</dockerfile.versionTagName>
+
+        <dockerfile.latestTagPrefix><!-- defined externally --></dockerfile.latestTagPrefix>
+        <dockerfile.latestTagSuffix><!-- defined externally --></dockerfile.latestTagSuffix>
+        <dockerfile.latestTagName>${dockerfile.latestTagPrefix}latest${dockerfile.latestTagSuffix}</dockerfile.latestTagName>
+
+        <dockerfile.imageName><!-- defined in submodules --></dockerfile.imageName>
+        <!-- Either ${dockerfile.repositoryUrl} or ${dockerfile.repositoryUrl} is required to be explicitly provided in the `mvn` command -->
+        <dockerfile.repositoryUrl><!-- defined externally --></dockerfile.repositoryUrl>
+        <dockerfile.repository>${dockerfile.repositoryUrl}/${dockerfile.imageName}</dockerfile.repository>
+        <!-- [Optional] The prefix for the base images in Dockerfile (mainly used in custom CI/CD pipelines to pull images from alternative locations) -->
+        <dockerfile.baseImagePrefix><!-- defined externally --></dockerfile.baseImagePrefix>
 
         <!-- json4s -->
 
@@ -195,6 +212,13 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
             </plugin>
         </plugins>
 
@@ -598,6 +622,13 @@
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-deploy-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
                         <executions>
                             <execution>
@@ -668,7 +699,7 @@
                                     <goal>push</goal>
                                 </goals>
                                 <configuration>
-                                    <tag>${project.version}</tag>
+                                    <tag>${dockerfile.versionTagName}</tag>
                                 </configuration>
                             </execution>
                             <execution>
@@ -678,12 +709,15 @@
                                     <goal>push</goal>
                                 </goals>
                                 <configuration>
-                                    <tag>latest</tag>
+                                    <tag>${dockerfile.latestTagName}</tag>
                                 </configuration>
                             </execution>
                         </executions>
                         <configuration>
-                            <repository>${dockerfile.repositoryUrl}/spline-spark-agent</repository>
+                            <repository>${dockerfile.repository}</repository>
+                            <buildArgs combine.children="append">
+                                <DOCKER_BASE_IMAGE_PREFIX>${dockerfile.baseImagePrefix}</DOCKER_BASE_IMAGE_PREFIX>
+                            </buildArgs>
                             <useMavenSettingsForAuth>true</useMavenSettingsForAuth>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
One can run examples like this:

```shell
docker run --rm \
  -e SPLINE_PRODUCER_URL=... \
  absaoss/spline-spark-agent:1.2.3
```
Parameters (env variables) allowed:
| Variable | Default value | Description |
| --- | --- | --- |
| SPLINE_PRODUCER_URL | http://host.docker.internal:8080/producer | Spline producer URL |
| SPLINE_MODE | REQUIRED | Spline mode |
| HTTP_PROXY_HOST |  | Java HTTP proxy host (per JVM spec) |
| HTTP_PROXY_PORT |  | Java HTTP proxy port (per JVM spec) | 
| HTTP_NON_PROXY_HOSTS |  | Java HTTP non-proxy hosts (per JVM spec) |

A docker image is built on a project root level, is activated by the Maven profile `docker`