### PR TITLE
bugfix/spline-69 hide more passwords

### DIFF
--- a/core/src/main/resources/spline.default.properties
+++ b/core/src/main/resources/spline.default.properties
@@ -101,5 +101,5 @@ spline.postProcessingFilter.dsPasswordReplace.nameRegexes=\
   (?i)password ,\
   (?i)passphrase
 spline.postProcessingFilter.dsPasswordReplace.valueRegexes=\
-  (?i)[?&;]password=([^&;]*)(?\=[&;])? ,\
+  (?i)[?&;](?:password|passphrase)=([^&;]*)(?\=[&;])? ,\
   //[^:]*:([^@]*)@(?:\\w+\\.)*\\w+

--- a/core/src/main/resources/spline.default.properties
+++ b/core/src/main/resources/spline.default.properties
@@ -90,13 +90,16 @@ spline.postProcessingFilter.composite.className=za.co.absa.spline.harvester.post
 # The classes must have a constructor with a single parameter of type {org.apache.commons.configuration.Configuration}
 #
 # Example:
-#   to enable password replacing in the data source URIs add "dsUriPasswordReplace" filter to the list:
-#spline.postProcessingFilter.composite.filters=dsUriPasswordReplace
+#   to enable password replacing in the data source URIs add "dsPasswordReplace" filter to the list:
+#spline.postProcessingFilter.composite.filters=dsPasswordReplace
 spline.postProcessingFilter.composite.filters=
 
 # This filter replaces password occurrences in the data source URIs
-spline.postProcessingFilter.dsUriPasswordReplace.className=za.co.absa.spline.harvester.postprocessing.DataSourcePasswordReplacingFilter
-spline.postProcessingFilter.dsUriPasswordReplace.replacement=*****
-spline.postProcessingFilter.dsUriPasswordReplace.regexes=\
-  [?&;]password=([^&;]*)(?\=[&;])? ,\
+spline.postProcessingFilter.dsPasswordReplace.className=za.co.absa.spline.harvester.postprocessing.DataSourcePasswordReplacingFilter
+spline.postProcessingFilter.dsPasswordReplace.replacement=*****
+spline.postProcessingFilter.dsPasswordReplace.nameRegexes=\
+  (?i)password ,\
+  (?i)passphrase
+spline.postProcessingFilter.dsPasswordReplace.valueRegexes=\
+  (?i)[?&;]password=([^&;]*)(?\=[&;])? ,\
   //[^:]*:([^@]*)@(?:\\w+\\.)*\\w+

--- a/core/src/main/resources/spline.default.properties
+++ b/core/src/main/resources/spline.default.properties
@@ -101,5 +101,5 @@ spline.postProcessingFilter.dsPasswordReplace.nameRegexes=\
   (?i)password ,\
   (?i)passphrase
 spline.postProcessingFilter.dsPasswordReplace.valueRegexes=\
-  (?i)[?&;](?:password|passphrase)=([^&;]*)(?\=[&;])? ,\
+  (?i)[?&;](?:password|passphrase)=([^&;]*) ,\
   //[^:]*:([^@]*)@(?:\\w+\\.)*\\w+

--- a/core/src/main/scala/za/co/absa/spline/harvester/postprocessing/DataSourcePasswordReplacingFilter.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/postprocessing/DataSourcePasswordReplacingFilter.scala
@@ -51,8 +51,8 @@ class DataSourcePasswordReplacingFilter(
 
   private val valueReplacer = new CaptureGroupReplacer(replacement)
 
-  private def filter(uri: String): String =
-    valueReplacer.replace(uri, sensitiveValueRegexes)
+  private def filter(str: String): String =
+    valueReplacer.replace(str, sensitiveValueRegexes)
 
   private def filter(map: Map[String, _]): Map[String, _] = map.map {
     case (k, _) if sensitiveNameRegexes.exists(_.pattern.matcher(k).matches) => k -> replacement

--- a/core/src/test/scala/za/co/absa/spline/harvester/postprocessing/DataSourcePasswordReplacingFilterSpec.scala
+++ b/core/src/test/scala/za/co/absa/spline/harvester/postprocessing/DataSourcePasswordReplacingFilterSpec.scala
@@ -21,7 +21,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import za.co.absa.spline.harvester.HarvestingContext
-import za.co.absa.spline.producer.model.v1_1.WriteOperation
+import za.co.absa.spline.producer.model.v1_1.{ReadOperation, WriteOperation}
 
 class DataSourcePasswordReplacingFilterSpec extends AnyFlatSpec with Matchers with MockitoSugar {
 
@@ -29,51 +29,66 @@ class DataSourcePasswordReplacingFilterSpec extends AnyFlatSpec with Matchers wi
     new PropertiesConfiguration(getClass.getResource("/spline.default.properties"))
       .subset("spline.postProcessingFilter.dsPasswordReplace")
 
-  private val ctxMock = mock[HarvestingContext]
+  private val dummyContext = mock[HarvestingContext]
 
   it should "mask secret in URL query parameter as `password=*****`" in { //NOSONAR
-    val wop = WriteOperation(
-      outputSource = "" +
-        "jdbc:sqlserver://database.windows.net:1433" +
-        ";user=sample" +
-        ";password=12345" + //NOSONAR
-        ";PASSWORD=" + //NOSONAR -- empty password is also a password
-        ";encrypt=true" +
-        ";trustServerCertificate=false" +
-        ";hostNameInCertificate=*.database.windows.net" +
-        ";loginTimeout=30:",
-      params = Some(Map(
-        "a" -> 42,
-        "b" -> Seq(null),
-        "c" -> None,
-        "url" -> "jdbc:postgresql://bob:secret@someHost:somePort/someDB",
-        "m" -> Map(
-          "url" -> "jdbc:postgresql://bob:secret@someHost:somePort/someDB",
-          "dbtable" -> "someTable",
-          "user" -> "someUser",
-          "PASSWORD" -> "somePassword" // NOSONAR
-        )
-      )),
-      append = false,
-      id = "",
-      name = None,
-      childIds = Nil,
-      extra = None)
-
-    val filter = new DataSourcePasswordReplacingFilter(defaultProperties)
-    val filteredOp = filter.processWriteOperation(wop, ctxMock)
-
-    filteredOp.outputSource shouldEqual "" +
+    val originalURL = "" +
       "jdbc:sqlserver://database.windows.net:1433" +
       ";user=sample" +
-      ";password=*****" + //NOSONAR <-- PASSWORD SHOULD BE SANITIZED
-      ";PASSWORD=*****" + //NOSONAR <-- PASSWORD SHOULD BE SANITIZED
+      ";password=12345" + //NOSONAR
+      ";PASSPHRASE=" + //NOSONAR -- empty password is also a password
       ";encrypt=true" +
       ";trustServerCertificate=false" +
       ";hostNameInCertificate=*.database.windows.net" +
       ";loginTimeout=30:"
 
-    filteredOp.params shouldEqual Some(Map(
+    val sanitizedURL = "" +
+      "jdbc:sqlserver://database.windows.net:1433" +
+      ";user=sample" +
+      ";password=*****" + //NOSONAR <-- PASSWORD SHOULD BE SANITIZED
+      ";PASSPHRASE=*****" + //NOSONAR <-- PASSWORD SHOULD BE SANITIZED
+      ";encrypt=true" +
+      ";trustServerCertificate=false" +
+      ";hostNameInCertificate=*.database.windows.net" +
+      ";loginTimeout=30:"
+
+    val rop = ReadOperation(Seq(originalURL), "", None, None, None, None)
+    val wop = WriteOperation(originalURL, append = false, "", None, Nil, None, None)
+
+    val filter = new DataSourcePasswordReplacingFilter(defaultProperties)
+
+    filter.processReadOperation(rop, dummyContext).inputSources shouldEqual Seq(sanitizedURL)
+    filter.processWriteOperation(wop, dummyContext).outputSource shouldEqual sanitizedURL
+  }
+
+  it should "mask secret in URL userinfo as `user:*****@host`" in {
+    val rop = ReadOperation(Seq("mongodb://bob:super_secret@mongodb.host.example.org:27017?authSource=admin"), "", None, None, None, None) //NOSONAR
+    val wop = WriteOperation("mongodb://bob:@mongodb.host.example.org:27017?authSource=admin", append = false, "", None, Nil, None, None) //NOSONAR
+
+    val filter = new DataSourcePasswordReplacingFilter(defaultProperties)
+
+    filter.processReadOperation(rop, dummyContext).inputSources shouldEqual Seq("mongodb://bob:*****@mongodb.host.example.org:27017?authSource=admin") //NOSONAR
+    filter.processWriteOperation(wop, dummyContext).outputSource shouldEqual "mongodb://bob:*****@mongodb.host.example.org:27017?authSource=admin" //NOSONAR
+  }
+
+  it should "mask secrets in 'params'" in {
+    val originalParams = Map(
+      "a" -> 42,
+      "b" -> Seq(null),
+      "c" -> None,
+      "m" -> Map(
+        "url" -> "jdbc:postgresql://bob:secret@someHost:somePort/someDB",
+        "dbtable" -> "someTable",
+        "user" -> "someUser",
+        "PASSPHRASE" -> "somePassword" // NOSONAR
+      ),
+      "url" -> "jdbc:postgresql://bob:secret@someHost:somePort/someDB",
+      "dbtable" -> "someTable",
+      "user" -> "someUser",
+      "password" -> "somePassword" // NOSONAR
+    )
+
+    val sanitizedParams = Map(
       "a" -> 42,
       "b" -> Seq(null),
       "c" -> None,
@@ -82,19 +97,21 @@ class DataSourcePasswordReplacingFilterSpec extends AnyFlatSpec with Matchers wi
         "url" -> "jdbc:postgresql://bob:*****@someHost:somePort/someDB",
         "dbtable" -> "someTable",
         "user" -> "someUser",
-        "PASSWORD" -> "*****" // NOSONAR
-      )
-    ))
-  }
+        "PASSPHRASE" -> "*****" // NOSONAR
+      ),
+      "url" -> "jdbc:postgresql://bob:*****@someHost:somePort/someDB",
+      "dbtable" -> "someTable",
+      "user" -> "someUser",
+      "password" -> "*****" // NOSONAR
+    )
 
-  it should "mask secret in URL userinfo as `user:*****@host`" in {
-    val wop1 = WriteOperation("mongodb://bob:super_secret@mongodb.host.example.org:27017?authSource=admin", append = false, "", None, Nil, None, None) //NOSONAR
-    val wop2 = WriteOperation("mongodb://bob:@mongodb.host.example.org:27017?authSource=admin", append = false, "", None, Nil, None, None)
+    val rop = ReadOperation(Nil, "", None, None, params = Some(originalParams), None)
+    val wop = WriteOperation("", append = false, "", None, Nil, params = Some(originalParams), None)
 
     val filter = new DataSourcePasswordReplacingFilter(defaultProperties)
 
-    filter.processWriteOperation(wop1, ctxMock).outputSource shouldEqual "mongodb://bob:*****@mongodb.host.example.org:27017?authSource=admin" //NOSONAR
-    filter.processWriteOperation(wop2, ctxMock).outputSource shouldEqual "mongodb://bob:*****@mongodb.host.example.org:27017?authSource=admin" //NOSONAR
+    filter.processReadOperation(rop, dummyContext).params shouldEqual Some(sanitizedParams)
+    filter.processWriteOperation(wop, dummyContext).params shouldEqual Some(sanitizedParams)
   }
 
 }


### PR DESCRIPTION
- Scan for sensitive read/write operation param names and values
- make default regexes case-insensitive
- change the filter logical name from `dsUriPasswordReplace` to `dsPasswordReplace`