### PR TITLE
Fix PostProcessingFilters custom filter name section

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ A custom filter class must implement `za.co.absa.spline.harvester.postprocessing
 with a single parameter of type `org.apache.commons.configuration.Configuration`.
 Then register and configure it like this:
 ```properties
-spline.postProcessingFilter.className=my-filter
+spline.postProcessingFilter=my-filter
 spline.postProcessingFilter.my-filter.className=my.awesome.CustomFilter
 spline.postProcessingFilter.my-filter.prop1=value1
 spline.postProcessingFilter.my-filter.prop2=value2


### PR DESCRIPTION
This is to ensure accuracy of configuration examples for reference. I stumbled upon this for a while. Only realised the className here is not required.