### PR TITLE
Bugfix/spline spark agent 230

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ A custom filter class must implement `za.co.absa.spline.harvester.postprocessing
 with a single parameter of type `org.apache.commons.configuration.Configuration`.
 Then register and configure it like this:
 ```properties
-spline.postProcessingFilter.className=my-filter
+spline.postProcessingFilter=my-filter
 spline.postProcessingFilter.my-filter.className=my.awesome.CustomFilter
 spline.postProcessingFilter.my-filter.prop1=value1
 spline.postProcessingFilter.my-filter.prop2=value2

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>za.co.absa.commons</groupId>
             <artifactId>commons_${scala.binary.version}</artifactId>
-            <version>0.0.27</version>
+            <version>0.0.28</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -620,6 +620,13 @@
                                 </goals>
                             </execution>
                         </executions>
+                        <configuration>
+                            <!--
+                                disable MIMA because of too many false positives caused by cross-compilation
+                                that leads to MIMA comparing snapshots compiled against different Scala or Spark versions.
+                            -->
+                            <skip>true</skip>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -451,7 +451,7 @@
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
-                <version>1.13</version>
+                <version>1.10</version>
             </dependency>
             <dependency>
                 <groupId>commons-lang</groupId>
@@ -466,12 +466,12 @@
             <dependency>
                 <groupId>commons-configuration</groupId>
                 <artifactId>commons-configuration</artifactId>
-                <version>1.10</version>
+                <version>1.6</version>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.6</version>
+                <version>2.4</version>
             </dependency>
 
             <!-- Logging -->


### PR DESCRIPTION
- Update Absa commons to ver 0.0.28
- Align other Apache commons versions with the ones used in Spark to minimize risk of potential binary incompatibilities.
- Fix readme typo (cherry pick from `develop`)
- Disable MIMA due to too many false positives