### PR TITLE
Updated Dockerfile location

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -66,7 +66,7 @@ Change your docker settings for at least have `cpu=2` and `memory=4096M`
 1. Build docker image
     ```shell script
     # build a docker image from the project root folder
-    docker build -f examples/Dockerfile . -t spline-spark-agent-examples:v0.1.0
+    docker build -f Dockerfile . -t spline-spark-agent-examples:v0.1.0
     ```
 
 2. Run docker image


### PR DESCRIPTION
I noticed there was no `Dockerfile` in the examples directory, and the only `Dockerfile` in this whole repo was at the root dir