### PR TITLE
spline #spline-spark-agent-248 AWS EMR error

### DIFF
--- a/bundle-3.0/pom.xml
+++ b/bundle-3.0/pom.xml
@@ -198,11 +198,6 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>commons-configuration</groupId>
-                <artifactId>commons-configuration</artifactId>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-crypto</artifactId>
                 <scope>provided</scope>


### PR DESCRIPTION
Include the `commons-configuration` into 3.0 bundle