### PR TITLE
Feature/agent 191 data source v2 support

### DIFF
--- a/core/src/main/scala/za/co/absa/spline/harvester/plugin/embedded/DataSourceV2Plugin.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/plugin/embedded/DataSourceV2Plugin.scala
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.spline.harvester.plugin.embedded
+
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.{SaveMode, SparkSession}
+import za.co.absa.commons.reflect.ReflectionUtils.extractFieldValue
+import za.co.absa.commons.reflect.extractors.SafeTypeMatchingExtractor
+import za.co.absa.spline.harvester.builder.SourceIdentifier
+import za.co.absa.spline.harvester.plugin.Plugin.{Params, Precedence, ReadNodeInfo, WriteNodeInfo}
+import za.co.absa.spline.harvester.plugin.embedded.DataSourceV2Plugin._
+import za.co.absa.spline.harvester.plugin.{Plugin, ReadNodeProcessing, WriteNodeProcessing}
+import za.co.absa.spline.harvester.qualifier.PathQualifier
+
+import javax.annotation.Priority
+import scala.language.reflectiveCalls
+import scala.util.{Success, Try}
+
+@Priority(Precedence.Normal)
+class DataSourceV2Plugin(
+  pathQualifier: PathQualifier,
+  session: SparkSession)
+  extends Plugin
+    with ReadNodeProcessing
+    with WriteNodeProcessing {
+
+  override val readNodeProcessor: PartialFunction[LogicalPlan, ReadNodeInfo] = {
+    case `_: DataSourceV2Relation`(relation) =>
+      val table = extractFieldValue[AnyRef](relation, "table")
+      val tableName = extractFieldValue[String](table, "name")
+      val identifier = extractFieldValue[AnyRef](relation, "identifier")
+      val options =  extractFieldValue[AnyRef](relation, "options")
+      val props = Map(
+        "table" -> Map("identifier" -> tableName),
+        "identifier" -> identifier,
+        "options" -> options)
+      (extractSourceIdFromTable(table), props)
+  }
+
+  override val writeNodeProcessor: PartialFunction[LogicalPlan, WriteNodeInfo] = {
+    case `_: V2WriteCommand`(writeCommand) => {
+      val namedRelation = extractFieldValue[AnyRef](writeCommand, "table")
+      val query = extractFieldValue[LogicalPlan](writeCommand, "query")
+
+      val tableName = extractFieldValue[AnyRef](namedRelation, "name")
+      val writeOptions = extractFieldValue[Map[String, String]](writeCommand, "writeOptions")
+      val isByName = extractFieldValue[Boolean](writeCommand, "isByName")
+
+      val props = Map(
+        "table" -> Map("identifier" -> tableName),
+        "writeOptions" -> writeOptions,
+        "isByName" -> isByName)
+
+      val sourceId = extractSourceIdFromRelation(namedRelation)
+
+      processV2WriteCommand(writeCommand, sourceId, query, props)
+    }
+
+    case `_: V2CreateTablePlan`(ctp) => {
+      val catalog = extractFieldValue[AnyRef](ctp, "catalog")
+      val identifier = extractFieldValue[AnyRef](ctp, "tableName")
+      val loadTableMethods = catalog.getClass.getMethods.filter(_.getName == "loadTable")
+      val table = loadTableMethods.flatMap(m => Try(m.invoke(catalog, identifier)).toOption).head
+      val sourceId = extractSourceIdFromTable(table)
+
+      val query = extractFieldValue[LogicalPlan](ctp, "query")
+
+      val partitioning = extractFieldValue[AnyRef](ctp, "partitioning")
+      val properties = extractFieldValue[Map[String, String]](ctp, "properties")
+      val writeOptions = extractFieldValue[Map[String, String]](ctp, "writeOptions")
+      val props = Map(
+        "table" -> Map("identifier" -> identifier.toString),
+        "partitioning" -> partitioning,
+        "properties" -> properties,
+        "writeOptions" -> writeOptions)
+
+      val commandSpecificProp = ctp match {
+        case `_: CreateTableAsSelect`(_) =>
+          "ignoreIfExists" -> extractFieldValue[Boolean](ctp, "ignoreIfExists")
+        case `_: ReplaceTableAsSelect`(_) =>
+          "orCreate" -> extractFieldValue[Boolean](ctp, "orCreate")
+      }
+
+      (sourceId, SaveMode.Overwrite, query, props + commandSpecificProp)
+    }
+  }
+
+  /**
+    * @param v2WriteCommand org.apache.spark.sql.catalyst.plans.logical.V2WriteCommand
+    */
+  def processV2WriteCommand(
+    v2WriteCommand: AnyRef,
+    sourceId: SourceIdentifier,
+    query: LogicalPlan,
+    props: Params
+  ): (SourceIdentifier, SaveMode, LogicalPlan, Params) = v2WriteCommand match {
+    case `_: AppendData`(_) =>
+      (sourceId, SaveMode.Append, query, props)
+
+    case `_: OverwriteByExpression`(obe) =>
+      val deleteExpr = extractFieldValue[AnyRef](obe, "deleteExpr")
+      (sourceId, SaveMode.Overwrite, query, props + ("deleteExpr" -> deleteExpr))
+
+    case `_: OverwritePartitionsDynamic`(_) =>
+      (sourceId, SaveMode.Overwrite, query, props)
+  }
+
+  /**
+    * @param namedRelation org.apache.spark.sql.catalyst.analysis.NamedRelation
+    */
+  private def extractSourceIdFromRelation(namedRelation: AnyRef): SourceIdentifier = {
+    val table = extractFieldValue[AnyRef](namedRelation, "table")
+    extractSourceIdFromTable(table)
+  }
+
+  /**
+    * @param table org.apache.spark.sql.connector.catalog.Table
+    */
+  private def extractSourceIdFromTable(table: AnyRef): SourceIdentifier = table match {
+    case `_: CassandraTable`(ct) =>
+      val metadata = extractFieldValue[AnyRef](ct, "metadata")
+      val keyspace = extractFieldValue[AnyRef](metadata, "keyspace")
+      val name = extractFieldValue[AnyRef](metadata, "name")
+      SourceIdentifier(Some("cassandra"), s"cassandra:$keyspace:$name")
+
+    case `_: DeltaTableV2`(dt) =>
+      val tableProps = extractFieldValue[java.util.Map[String, String]](dt, "properties")
+      val uri = tableProps.get("location")
+      val provider = tableProps.get("provider")
+      SourceIdentifier(Some(provider), uri)
+
+    case `_: FileTable`(ft) =>
+      val format = extractFieldValue[String](ft, "formatName").toLowerCase
+      val paths = extractFieldValue[Seq[String]](ft, "paths")
+      SourceIdentifier(Some(format), paths: _*)
+  }
+}
+
+object DataSourceV2Plugin {
+  object `_: V2WriteCommand` extends SafeTypeMatchingExtractor[AnyRef](
+    "org.apache.spark.sql.catalyst.plans.logical.V2WriteCommand")
+
+  object `_: AppendData` extends SafeTypeMatchingExtractor[AnyRef](
+    "org.apache.spark.sql.catalyst.plans.logical.AppendData")
+
+  object `_: OverwriteByExpression` extends SafeTypeMatchingExtractor[AnyRef](
+    "org.apache.spark.sql.catalyst.plans.logical.OverwriteByExpression")
+
+  object `_: OverwritePartitionsDynamic` extends SafeTypeMatchingExtractor[AnyRef](
+    "org.apache.spark.sql.catalyst.plans.logical.OverwritePartitionsDynamic")
+
+  object `_: V2CreateTablePlan` extends SafeTypeMatchingExtractor[AnyRef](
+    "org.apache.spark.sql.catalyst.plans.logical.V2CreateTablePlan")
+
+  object `_: CreateTableAsSelect` extends SafeTypeMatchingExtractor[AnyRef](
+    "org.apache.spark.sql.catalyst.plans.logical.CreateTableAsSelect")
+
+  object `_: ReplaceTableAsSelect` extends SafeTypeMatchingExtractor[AnyRef](
+    "org.apache.spark.sql.catalyst.plans.logical.ReplaceTableAsSelect")
+
+  object `_: DataSourceV2Relation` extends SafeTypeMatchingExtractor[AnyRef](
+    "org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation")
+
+  object `_: FileTable` extends SafeTypeMatchingExtractor[AnyRef](
+    "org.apache.spark.sql.execution.datasources.v2.FileTable")
+
+  object `_: DeltaTableV2` extends SafeTypeMatchingExtractor[AnyRef](
+    "org.apache.spark.sql.delta.catalog.DeltaTableV2")
+
+  object `_: CassandraTable` extends SafeTypeMatchingExtractor[AnyRef](
+    "com.datastax.spark.connector.datasource.CassandraTable")
+
+}

--- a/integration-tests/src/test/scala/za/co/absa/spline/DeltaDSV2Spec.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/DeltaDSV2Spec.scala
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package za.co.absa.spline
+
+import org.apache.spark.SPARK_VERSION
+import org.apache.spark.sql.catalyst.expressions.Literal
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+import za.co.absa.commons.scalatest.ConditionalTestTags.ignoreIf
+import za.co.absa.commons.version.Version.VersionStringInterpolator
+import za.co.absa.spline.test.fixture.spline.SplineFixture
+import za.co.absa.spline.test.fixture.{SparkDatabaseFixture, SparkFixture}
+
+class DeltaDSV2Spec extends AsyncFlatSpec
+  with Matchers
+  with SparkFixture
+  with SplineFixture
+  with SparkDatabaseFixture {
+
+  it should "support AppendData V2 command" taggedAs ignoreIf(ver"$SPARK_VERSION" < ver"3.0.0") in
+    withCustomSparkSession(_
+      .enableHiveSupport
+      .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+      .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+    ) { implicit spark =>
+      withLineageTracking { lineageCaptor =>
+        withDatabase("testDB") {
+          val testData = {
+            import spark.implicits._
+            Seq((1014, "Warsaw"), (1002, "Corte")).toDF("ID", "NAME")
+          }
+
+          for {
+            (plan1, Seq(event1)) <- lineageCaptor.lineageOf {
+              spark.sql(s"CREATE TABLE foo (ID int, NAME string) USING delta")
+              testData.write.format("delta").mode("append").saveAsTable("foo")
+            }
+          } yield {
+            plan1.id.get shouldEqual event1.planId
+            plan1.operations.write.append shouldBe true
+            plan1.operations.write.extra.get("destinationType") shouldBe Some("delta")
+            plan1.operations.write.outputSource shouldBe s"file:$warehouseDir/testdb.db/foo"
+          }
+        }
+      }
+    }
+
+  it should "support OverwriteByExpression V2 command without deleteExpression" taggedAs ignoreIf(ver"$SPARK_VERSION" < ver"3.0.0") in
+    withCustomSparkSession(_
+      .enableHiveSupport
+      .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+      .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+    ) { implicit spark =>
+      withLineageTracking { lineageCaptor =>
+        withDatabase("testDB") {
+          val testData = {
+            import spark.implicits._
+            Seq((1014, "Warsaw"), (1002, "Corte")).toDF("ID", "NAME")
+          }
+
+          for {
+            (plan1, Seq(event1)) <- lineageCaptor.lineageOf {
+              spark.sql(s"CREATE TABLE foo (ID int, NAME string) USING delta")
+              testData.write.format("delta").mode("overwrite").insertInto("foo")
+            }
+          } yield {
+            plan1.id.get shouldEqual event1.planId
+            plan1.operations.write.append shouldBe false
+            plan1.operations.write.extra.get("destinationType") shouldBe Some("delta")
+            plan1.operations.write.params.get.apply("deleteExpr") should be(Literal(true))
+            plan1.operations.write.outputSource shouldBe s"file:$warehouseDir/testdb.db/foo"
+          }
+        }
+      }
+    }
+
+  it should "support OverwriteByExpression V2 command with deleteExpression" taggedAs ignoreIf(ver"$SPARK_VERSION" < ver"3.0.0") in
+    withCustomSparkSession(_
+      .enableHiveSupport
+      .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+      .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+    ) { implicit spark =>
+      withLineageTracking { lineageCaptor =>
+        withDatabase("testDB") {
+          val testData = {
+            import spark.implicits._
+            Seq((1014, "Warsaw"), (1002, "Corte")).toDF("ID", "NAME")
+          }
+          testData.createOrReplaceTempView("tempdata")
+
+          for {
+            (plan1, Seq(event1)) <- lineageCaptor.lineageOf {
+              spark.sql(s"CREATE TABLE foo (ID int, NAME string) USING delta PARTITIONED BY (ID)")
+              spark.sql("""
+                          |INSERT OVERWRITE foo PARTITION (ID = 222222)
+                          |  (SELECT NAME FROM tempdata WHERE NAME = 'Warsaw')
+                          |""".stripMargin)
+            }
+          } yield {
+            plan1.id.get shouldEqual event1.planId
+            plan1.operations.write.append shouldBe false
+            plan1.operations.write.extra.get("destinationType") shouldBe Some("delta")
+            plan1.operations.write.params.get.apply("deleteExpr") should not be(Literal(true))
+            plan1.operations.write.outputSource shouldBe s"file:$warehouseDir/testdb.db/foo"
+          }
+        }
+      }
+    }
+
+  /**
+    * Even though the code actually does dynamic partition overwrite,
+    * the spark command generated is OverwriteByExpression.
+    * Keeping this test in case the command will be used in future Spark versions.
+    */
+  it should "support OverwritePartitionsDynamic V2 command" taggedAs ignoreIf(ver"$SPARK_VERSION" < ver"3.0.0") in
+    withCustomSparkSession(_
+      .enableHiveSupport
+      .config("hive.exec.dynamic.partition", "true")
+      .config("hive.exec.dynamic.partition.mode", "nonstrict")
+      .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+      .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+    ) { implicit spark =>
+      withLineageTracking { lineageCaptor =>
+        withDatabase("testDB") {
+          val testData = {
+            import spark.implicits._
+            Seq((1014, "Warsaw"), (1002, "Corte")).toDF("ID", "NAME")
+          }
+          testData.createOrReplaceTempView("tempdata")
+
+          for {
+            (plan1, Seq(event1)) <- lineageCaptor.lineageOf {
+              spark.sql(s"CREATE TABLE foo (ID int, NAME string) USING delta PARTITIONED BY (NAME)")
+              spark.sql("""
+                          |INSERT OVERWRITE foo PARTITION (NAME)
+                          |  (SELECT ID, NAME FROM tempdata WHERE NAME = 'Warsaw')
+                          |""".stripMargin)
+            }
+          } yield {
+            plan1.id.get shouldEqual event1.planId
+            plan1.operations.write.append shouldBe false
+            plan1.operations.write.extra.get("destinationType") shouldBe Some("delta")
+            plan1.operations.write.outputSource shouldBe s"file:$warehouseDir/testdb.db/foo"
+          }
+        }
+      }
+    }
+
+  it should "support CreateTableAsSelect V2 command" taggedAs ignoreIf(ver"$SPARK_VERSION" < ver"3.0.0") in
+    withCustomSparkSession(_
+      .enableHiveSupport
+      .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+      .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+    ) { implicit spark =>
+      withLineageTracking { lineageCaptor =>
+        withDatabase("testDB") {
+          val testData = {
+            import spark.implicits._
+            Seq((1014, "Warsaw"), (1002, "Corte")).toDF("ID", "NAME")
+          }
+
+          for {
+            (plan1, Seq(event1)) <- lineageCaptor.lineageOf {
+              testData.write.format("delta").saveAsTable("foo")
+            }
+          } yield {
+            plan1.id.get shouldEqual event1.planId
+            plan1.operations.write.append shouldBe false
+            plan1.operations.write.extra.get("destinationType") shouldBe Some("delta")
+            plan1.operations.write.outputSource shouldBe s"file:$warehouseDir/testdb.db/foo"
+          }
+        }
+      }
+    }
+
+  it should "support ReplaceTableAsSelect V2 command" taggedAs ignoreIf(ver"$SPARK_VERSION" < ver"3.0.0") in
+    withCustomSparkSession(_
+      .enableHiveSupport
+      .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+      .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+    ) { implicit spark =>
+      withLineageTracking { lineageCaptor =>
+        withDatabase("testDB") {
+          val testData = {
+            import spark.implicits._
+            Seq((1014, "Warsaw"), (1002, "Corte")).toDF("ID", "NAME")
+          }
+
+          for {
+            (plan1, Seq(event1)) <- lineageCaptor.lineageOf {
+              spark.sql(s"CREATE TABLE foo (toBeOrNotToBe boolean) USING delta")
+              testData.write.format("delta").mode("overwrite").option("overwriteSchema", "true").saveAsTable("foo")
+            }
+          } yield {
+            plan1.id.get shouldEqual event1.planId
+            plan1.operations.write.append shouldBe false
+            plan1.operations.write.extra.get("destinationType") shouldBe Some("delta")
+            plan1.operations.write.outputSource shouldBe s"file:$warehouseDir/testdb.db/foo"
+          }
+        }
+      }
+    }
+}

--- a/integration-tests/src/test/scala/za/co/absa/spline/JsonDSV2Spec.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/JsonDSV2Spec.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package za.co.absa.spline
+
+import org.apache.spark.SPARK_VERSION
+import org.apache.spark.sql.catalyst.expressions.Literal
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+import za.co.absa.commons.io.TempDirectory
+import za.co.absa.commons.scalatest.ConditionalTestTags.ignoreIf
+import za.co.absa.commons.version.Version.VersionStringInterpolator
+import za.co.absa.spline.test.fixture.spline.SplineFixture
+import za.co.absa.spline.test.fixture.{SparkDatabaseFixture, SparkFixture}
+
+/**
+  *  Json DataSource V2 is not used by default in current Spark (3.1.x)
+  *  This test is here to make sure we are ready for the Data Source V2 and as a starting point for future developments
+  */
+class JsonDSV2Spec extends AsyncFlatSpec
+  with Matchers
+  with SparkFixture
+  with SplineFixture
+  with SparkDatabaseFixture {
+
+  val jsonDir: String = TempDirectory("SparkFixture", "UnitTestJson", pathOnly = true).deleteOnExit().path.toString.stripSuffix("/")
+
+  it should "support json V2 command" taggedAs ignoreIf(ver"$SPARK_VERSION" < ver"3.0.0") in
+    withCustomSparkSession(_
+      .config("spark.sql.sources.useV1SourceList", "") // use V2 by default
+    ) { implicit spark =>
+      withLineageTracking { lineageCaptor =>
+        val testData = {
+          import spark.implicits._
+          Seq((1014, "Warsaw"), (1002, "Corte")).toDF("ID", "NAME")
+        }
+        for {
+          (plan1, Seq(event1)) <- lineageCaptor.lineageOf {
+            testData.write.json(s"$jsonDir/jsonV2")
+          }
+          (plan2, Seq(event2)) <- lineageCaptor.lineageOf {
+            val df = spark.read.json(s"$jsonDir/jsonV2")
+            df.write.json(s"$jsonDir/jsonV2-2")
+          }
+        } yield {
+          plan1.id.get shouldEqual event1.planId
+          plan1.operations.write.append shouldBe false
+          plan1.operations.write.extra.get("destinationType") shouldBe Some("json")
+          plan1.operations.write.outputSource shouldBe s"file:$jsonDir/jsonV2"
+
+          plan2.operations.reads.get(0).inputSources.head shouldBe s"file:$jsonDir/jsonV2"
+        }
+      }
+    }
+
+
+
+}


### PR DESCRIPTION
I was able to do most of the things in backward compatible way:
- The plugin for Delta, Cassandra and Json (probably will work for other file based DS)
- tests for delta and json

Cassandra connector is not backward compatible, so the test is not included. I don't know if it makes sense to make a special module just for that. We could just add the test to the 1.0 where it will not be a problem.