### PR TITLE
spark agent #272 fix duplicated attribute ids

### DIFF
--- a/core/src/main/scala/za/co/absa/spline/harvester/ComponentCreatorFactory.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/ComponentCreatorFactory.scala
@@ -25,7 +25,10 @@ class ComponentCreatorFactory {
   val dataConverter = new DataConverter
   val dataTypeConverter = new DataTypeConverter with CachingConverter
 
-  private[this] val lastId = new AtomicInteger(0)
+  private[this] val lastOperationId = new AtomicInteger(0)
+  private[this] val lastAttributeId = new AtomicInteger(0)
 
-  def nextId: Int = lastId.getAndIncrement()
+  def nextOperationId: Int = lastOperationId.getAndIncrement()
+  def nextAttributeId: Int = lastAttributeId.getAndIncrement()
+
 }

--- a/core/src/main/scala/za/co/absa/spline/harvester/LineageHarvester.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/LineageHarvester.scala
@@ -89,7 +89,7 @@ class LineageHarvester(
       val writeOp = writeOpBuilder.build()
 
       val (opReads, opOthers) =
-        ((Vector.empty[ReadOperation], Vector.empty[DataOperation]) /: restOps) {
+        restOps.foldLeft((Vector.empty[ReadOperation], Vector.empty[DataOperation])) {
           case ((accRead, accOther), opRead: ReadOperation) => (accRead :+ opRead, accOther)
           case ((accRead, accOther), opOther: DataOperation) => (accRead, accOther :+ opOther)
         }
@@ -181,7 +181,7 @@ class LineageHarvester(
     }
 
     val builders = traverseAndCollect(Nil, Map.empty, Seq((rootOp, null)))
-    builders.sortedTopologicallyBy(_.id, _.childIds, reverse = true)
+    builders.sortedTopologicallyBy(_.operationId, _.childIds, reverse = true)
   }
 
   private def createOperationBuilder(op: LogicalPlan): OperationNodeBuilder =

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/GenericNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/GenericNodeBuilder.scala
@@ -35,7 +35,7 @@ class GenericNodeBuilder
 
   override def build(): DataOperation = {
     val dop = DataOperation(
-      id = id,
+      id = operationId,
       name = operation.nodeName.asOption,
       childIds = childIds.asOption,
       output = outputAttributes.map(_.id).asOption,

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/JoinNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/JoinNodeBuilder.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.spline.harvester.builder
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.plans.logical.Join
+import za.co.absa.spline.harvester.ComponentCreatorFactory
+import za.co.absa.spline.harvester.postprocessing.PostProcessor
+import za.co.absa.spline.producer.model.v1_1.DataOperation
+
+class JoinNodeBuilder
+  (override val operation: Join)
+  (override val componentCreatorFactory: ComponentCreatorFactory, postProcessor: PostProcessor)
+  extends GenericNodeBuilder(operation)(componentCreatorFactory, postProcessor) with Logging {
+
+  override def build(): DataOperation = {
+
+    val duplicates = operation.output.groupBy(_.exprId).collect { case (x, List(_,_,_*)) => x }
+    if (duplicates.nonEmpty) {
+      logError(s"Duplicated attributes found in Join operation output, ExprIds of duplicates: $duplicates")
+    }
+
+    super.build()
+  }
+
+}

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/JoinNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/JoinNodeBuilder.scala
@@ -29,9 +29,9 @@ class JoinNodeBuilder
 
   override def build(): DataOperation = {
 
-    val duplicates = operation.output.groupBy(_.exprId).collect { case (x, List(_,_,_*)) => x }
+    val duplicates = operation.output.groupBy(_.exprId).collect { case (exprId, attrs) if attrs.length > 1 => exprId }
     if (duplicates.nonEmpty) {
-      logError(s"Duplicated attributes found in Join operation output, ExprIds of duplicates: $duplicates")
+      logWarning(s"Duplicated attributes found in Join operation output, ExprIds of duplicates: $duplicates")
     }
 
     super.build()

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/OperationNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/OperationNodeBuilder.scala
@@ -28,7 +28,7 @@ trait OperationNodeBuilder {
 
   protected type R
 
-  val id: OperationId = componentCreatorFactory.nextId.toString
+  val operationId: OperationId = componentCreatorFactory.nextOperationId.toString
 
   private var childBuilders: Seq[OperationNodeBuilder] = Nil
 
@@ -42,7 +42,7 @@ trait OperationNodeBuilder {
 
   protected lazy val attributeConverter =
     new AttributeConverter(
-      componentCreatorFactory.dataTypeConverter,
+      componentCreatorFactory,
       resolveAttributeChild,
       childBuilders.map(_.outputExprToAttMap).reduceOption(_ ++ _).getOrElse(Map.empty),
       exprToRefConverter
@@ -73,7 +73,7 @@ trait OperationNodeBuilder {
   private def outputExprToAttMap: Map[sparkExprssions.ExprId, Attribute] =
     operation.output.map(_.exprId).zip(outputAttributes).toMap
 
-  def childIds: Seq[OperationId] = childBuilders.map(_.id)
+  def childIds: Seq[OperationId] = childBuilders.map(_.operationId)
 
   lazy val functionalExpressions: Seq[FunctionalExpression] = expressionConverter.values
 

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/OperationNodeBuilderFactory.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/OperationNodeBuilderFactory.scala
@@ -16,7 +16,7 @@
 
 package za.co.absa.spline.harvester.builder
 
-import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Generate, LogicalPlan, Project, Union, Window}
+import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Generate, LogicalPlan, Project, Union, Window, Join}
 import za.co.absa.spline.harvester.ComponentCreatorFactory
 import za.co.absa.spline.harvester.builder.read.{ReadCommand, ReadNodeBuilder}
 import za.co.absa.spline.harvester.builder.write.{WriteCommand, WriteNodeBuilder}
@@ -38,6 +38,7 @@ class OperationNodeBuilderFactory(
     case a: Aggregate => new AggregateNodeBuilder(a)(componentCreatorFactory, postProcessor)
     case g: Generate => new GenerateNodeBuilder(g)(componentCreatorFactory, postProcessor)
     case w: Window => new WindowNodeBuilder(w)(componentCreatorFactory, postProcessor)
+    case j: Join => new JoinNodeBuilder(j)(componentCreatorFactory, postProcessor)
     case _ => new GenericNodeBuilder(lp)(componentCreatorFactory, postProcessor)
   }
 }

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/read/ReadNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/read/ReadNodeBuilder.scala
@@ -35,7 +35,7 @@ class ReadNodeBuilder
   override def build(): ReadOperation = {
     val rop = ReadOperation(
       inputSources = command.sourceIdentifier.uris,
-      id = id,
+      id = operationId,
       name = operation.nodeName.asOption,
       output = outputAttributes.map(_.id).asOption,
       params = Map(command.params.toSeq: _*).asOption,

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/write/WriteNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/write/WriteNodeBuilder.scala
@@ -38,7 +38,7 @@ class WriteNodeBuilder
     val wop = WriteOperation(
       outputSource = uri,
       append = command.mode == SaveMode.Append,
-      id = id,
+      id = operationId,
       name = command.name.asOption,
       childIds = childIds,
       params = Map(command.params.toSeq: _*).asOption,

--- a/integration-tests/src/test/scala/za/co/absa/spline/DuplicatedExprIdsSpec.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/DuplicatedExprIdsSpec.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.spline
+
+import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.functions.col
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+import za.co.absa.commons.io.TempDirectory
+import za.co.absa.commons.lang.CollectionImplicits._
+import za.co.absa.spline.test.fixture.SparkFixture
+import za.co.absa.spline.test.fixture.spline.SplineFixture
+
+
+class DuplicatedExprIdsSpec extends AsyncFlatSpec
+  with Matchers
+  with SparkFixture
+  with SplineFixture {
+
+  private val tempPath = TempDirectory(prefix = "dupl", pathOnly = true).deleteOnExit().path.toFile.getAbsolutePath
+
+  it should "not create duplicated ids in spline plan" in
+    withNewSparkSession { implicit spark =>
+      withLineageTracking { captor =>
+        import spark.implicits._
+
+        val testData = Seq(("adcde1_12938597", 162)).toDF("unique_id", "total_commission")
+
+        for {
+          (plan1, Seq(event1)) <- captor.lineageOf {
+
+            val commonDf = testData
+              .withColumn("commission", col("total_commission"))
+              .drop("total_commission")
+
+            val rightJoinerDf = commonDf
+              .withColumnRenamed("commission", "foo")
+
+            val joined = commonDf.join(rightJoinerDf, usingColumns = Seq("unique_id"))
+
+            joined
+              .write
+              .mode(SaveMode.Overwrite)
+              .json(tempPath)
+          }
+        } yield {
+          val attributes = plan1.attributes.get
+          attributes.size shouldEqual attributes.distinctBy(_.id).size
+
+          val Seq(commission1, commission2) = attributes.filter(_.name == "commission")
+          commission1.childRefs.get.head shouldNot equal(commission2.childRefs.get.head)
+        }
+      }
+    }
+
+}


### PR DESCRIPTION
- remove deprecated symbol `/:`