### PR TITLE
issue #91 Remove Scalaz and minimize JAR

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -15,7 +15,8 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>agent-core_2.11</artifactId>
@@ -80,10 +81,6 @@
         <dependency>
             <groupId>org.json4s</groupId>
             <artifactId>json4s-ext_${scala.binary.version}</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.scalaz</groupId>
-            <artifactId>scalaz-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scalaj</groupId>

--- a/core/src/main/scala/za/co/absa/commons/CollectionImplicits.scala
+++ b/core/src/main/scala/za/co/absa/commons/CollectionImplicits.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons
+
+object CollectionImplicits {
+
+  implicit class MapOps[A, B](val m1: Map[A, B]) extends AnyVal {
+
+    /**
+     * Mappend - a simpler equivalent of Scalaz's `|+|` for maps.
+     * Merges two maps summing values for keys existing in both maps (`m1` and `m2`).
+     *
+     * @param m2 another map
+     * @return `m1 ++ m2` where values of intersecting keys are summed up
+     */
+    def |+|[C >: B : Numeric](m2: Map[A, C]): Map[A, C] = {
+      (m1.toSeq ++ m2.toSeq)
+        .groupBy { case (k, _) => k }
+        .map { case (k, pairs) =>
+          k -> pairs.map { case (_, v) => v }.sum
+        }
+    }
+  }
+}

--- a/core/src/main/scala/za/co/absa/spline/harvester/LineageHarvester.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/LineageHarvester.scala
@@ -21,7 +21,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.execution.{LeafExecNode, SparkPlan}
-import scalaz.Scalaz._
+import za.co.absa.commons.CollectionImplicits._
 import za.co.absa.commons.graph.GraphImplicits._
 import za.co.absa.commons.lang.OptionImplicits._
 import za.co.absa.commons.reflect.ReflectionUtils
@@ -34,7 +34,7 @@ import za.co.absa.spline.harvester.builder.write.{WriteCommand, WriteCommandExtr
 import za.co.absa.spline.harvester.conf.SplineConfigurer.SplineMode
 import za.co.absa.spline.harvester.conf.SplineConfigurer.SplineMode.SplineMode
 import za.co.absa.spline.harvester.iwd.IgnoredWriteDetectionStrategy
-import za.co.absa.spline.harvester.logging.{ObjectStructureDumper, ObjectStructureLogging}
+import za.co.absa.spline.harvester.logging.ObjectStructureLogging
 import za.co.absa.spline.harvester.postprocessing.PostProcessor
 import za.co.absa.spline.producer.model.v1_1._
 
@@ -111,9 +111,10 @@ class LineageHarvester(
         None
       }
       else {
-        val errorOrDuration = result.toDisjunction.toEither
-        val maybeError = errorOrDuration.left.toOption
-        val maybeDuration = errorOrDuration.right.toOption
+        val (maybeError, maybeDuration) = result match {
+          case Failure(e) => (Some(e), None)
+          case Success(d) => (None, Some(d))
+        }
 
         val eventExtra = Map[String, Any](
           ExecutionEventExtra.AppId -> ctx.session.sparkContext.applicationId,

--- a/core/src/test/scala/za/co/absa/commons/CollectionImplicitsSpec.scala
+++ b/core/src/test/scala/za/co/absa/commons/CollectionImplicitsSpec.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import za.co.absa.commons.CollectionImplicits._
+
+class CollectionImplicitsSpec
+  extends AnyFlatSpec
+    with Matchers {
+
+  behavior of "MapOps.|+|"
+
+  it should "merge two maps with append" in {
+    val m1 = Map("a" -> 1, "b" -> 1)
+    val m2 = Map("b" -> 1, "c" -> 1)
+    (m1 |+| m2) should equal(Map("a" -> 1, "b" -> 2, "c" -> 1))
+  }
+
+  it should "ignore empty maps" in {
+    (Map.empty[String, Int] |+| Map.empty[String, Int]) should be(empty)
+    (Map.empty[String, Int] |+| Map("a" -> 1)) should equal(Map("a" -> 1))
+    (Map("a" -> 1) |+| Map.empty[String, Int]) should equal(Map("a" -> 1))
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -513,11 +513,7 @@
 
             <!-- Others -->
 
-            <dependency>
-                <groupId>org.scalaz</groupId>
-                <artifactId>scalaz-core_${scala.binary.version}</artifactId>
-                <version>7.2.29</version>
-            </dependency>
+
 
             <!-- Test scope dependencies -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -272,9 +272,24 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.2.1</version>
+                    <version>3.2.4</version>
                     <configuration>
                         <createDependencyReducedPom>false</createDependencyReducedPom>
+                        <minimizeJar>true</minimizeJar>
+                        <filters>
+                            <filter>
+                                <artifact>za.co.absa.spline.agent.spark:agent-core_${scala.binary.version}</artifact>
+                                <includes>
+                                    <include>**</include>
+                                </includes>
+                            </filter>
+                            <filter>
+                                <artifact>za.co.absa.commons:commons_${scala.binary.version}</artifact>
+                                <includes>
+                                    <include>**</include>
+                                </includes>
+                            </filter>
+                        </filters>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
- Removed `scalaz`
- Enabled `<minimizeJar> in the _maven-shade-plugin_. For that I had to modified the qusiquoted code in the `HarvesterJsonSerDe` slightly, so that all its dependencies appear in _imports_ and are visible to the Shade plugin.

As a result, the total size of the bundle JAR decreased from about 12Mb to 3.7Mb (for Scala 2.11)

Remaining dependencies are (for _Spark 2.4_):
```
[INFO] +- za.co.absa.spline.agent.spark:agent-core_2.11:jar:0.6.5-SNAPSHOT:compile
[INFO] |  +- za.co.absa.commons:commons_2.11:jar:0.0.31:compile
[INFO] |  +- org.json4s:json4s-ext_2.11:jar:3.5.3:compile
[INFO] |  |  \- org.joda:joda-convert:jar:1.8.1:compile
[INFO] |  +- org.scalaj:scalaj-http_2.11:jar:2.4.1:compile
[INFO] |  +- io.github.classgraph:classgraph:jar:4.8.116:compile
[INFO] |  \- org.scala-graph:graph-core_2.11:jar:1.12.5:compile
```