### PR TITLE
issue #328 fix: Lineage harvester output is not deterministic

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>za.co.absa.commons</groupId>
             <artifactId>commons_${scala.binary.version}</artifactId>
-            <version>0.0.31</version>
+            <version>0.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>

--- a/examples/src/main/scala/za/co/absa/spline/example/batch/WindowFunctionJob.scala
+++ b/examples/src/main/scala/za/co/absa/spline/example/batch/WindowFunctionJob.scala
@@ -16,7 +16,6 @@
 
 package za.co.absa.spline.example.batch
 
-import za.co.absa.commons.io.TempFile
 import za.co.absa.spline.SparkApp
 
 /**
@@ -25,8 +24,6 @@ import za.co.absa.spline.SparkApp
  *
  */
 object WindowFunctionJob extends SparkApp("Window Function Job") {
-
-  private val filePath1 = TempFile("file1", ".xlsx", pathOnly = false).deleteOnExit().path.toAbsolutePath.toString
 
   import org.apache.spark.sql._
   import org.apache.spark.sql.expressions._
@@ -77,5 +74,5 @@ object WindowFunctionJob extends SparkApp("Window Function Job") {
     .format("com.crealytics.spark.excel")
     .option("header", "true")
     .mode("overwrite")
-    .save(filePath1)
+    .save("data/output/batch/window_function_job_result")
 }


### PR DESCRIPTION
- upgraded to _ABSA Commons 0.1.0_ (waiting for release)
- excluded `ExprId` from capturing
- changed `WindowFunctionJob` output path to a constant value