### PR TITLE
issue #348 Capture more details about object data types

### DIFF
--- a/core/src/main/scala/za/co/absa/spline/harvester/converter/DataTypeConverter.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/converter/DataTypeConverter.scala
@@ -38,7 +38,7 @@ class DataTypeConverter(idGen: IdGenerator[Any, UUID]) extends Converter {
         Array(idGen.nextId(), convert(arrayType.elementType -> arrayType.containsNull).id, nullable)
 
       case otherType: st.DataType =>
-        Simple(idGen.nextId(), otherType.typeName, nullable)
+        Simple(idGen.nextId(), otherType.simpleString, nullable)
     }
   }
 

--- a/integration-tests/src/test/scala/za/co/absa/spline/harvester/LineageHarvesterSpec.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/harvester/LineageHarvesterSpec.scala
@@ -409,7 +409,7 @@ object LineageHarvesterSpec extends Matchers {
 
   private def tmpDest: String = TempDirectory(pathOnly = true).deleteOnExit().path.toString
 
-  private val integerType = dt.Simple(UUID.randomUUID(), "integer", nullable = false)
+  private val integerType = dt.Simple(UUID.randomUUID(), "int", nullable = false)
   private val doubleType = dt.Simple(UUID.randomUUID(), "double", nullable = false)
   private val doubleNullableType = dt.Simple(UUID.randomUUID(), "double", nullable = true)
   private val stringType = dt.Simple(UUID.randomUUID(), "string", nullable = true)


### PR DESCRIPTION
in `DataTypeConverter` call `DataType.simpleString` instead of `DataType.typeName`