### PR TITLE
issue #370 Spark Config :: Arrays properties don't work

### DIFF
--- a/core/src/main/scala/za/co/absa/spline/harvester/conf/HadoopConfiguration.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/conf/HadoopConfiguration.scala
@@ -16,11 +16,10 @@
 
 package za.co.absa.spline.harvester.conf
 
-import java.util
-
 import org.apache.hadoop.conf.{Configuration => SparkHadoopConf}
 
-import scala.collection.JavaConverters._
+import java.util
+import java.util.function.Consumer
 
 
 /**
@@ -28,13 +27,17 @@ import scala.collection.JavaConverters._
  *
  * @param shc A source of Hadoop configuration
  */
-class HadoopConfiguration(shc: SparkHadoopConf) extends ReadOnlyConfiguration {
+class HadoopConfiguration(shc: SparkHadoopConf)
+  extends ReadOnlyConfiguration
+    with MapLikeConfigurationAdapter {
 
-  override def getProperty(key: String): AnyRef = shc get key
-
-  override def getKeys: util.Iterator[String] = shc.iterator.asScala.map(_.getKey).asJava
-
-  override def containsKey(key: String): Boolean = Option(shc get key).isDefined
-
-  override def isEmpty: Boolean = shc.size < 1
+  override protected def propertiesMap: util.Map[String, _ <: AnyRef] = {
+    val aMap = new util.HashMap[String, String]()
+    shc.iterator().forEachRemaining(new Consumer[util.Map.Entry[String, String]] {
+      override def accept(t: util.Map.Entry[String, String]): Unit = {
+        aMap.put(t.getKey, t.getValue)
+      }
+    })
+    aMap
+  }
 }

--- a/core/src/main/scala/za/co/absa/spline/harvester/conf/MapLikeConfigurationAdapter.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/conf/MapLikeConfigurationAdapter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ABSA Group Limited
+ * Copyright 2021 ABSA Group Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,23 @@
 
 package za.co.absa.spline.harvester.conf
 
-import org.apache.spark.SparkConf
+import org.apache.commons.configuration.MapConfiguration
 
-class SparkConfigurationTest extends ReadOnlyConfigurationTest {
+import java.util
 
-  override protected val givenConf = new SparkConfiguration(new SparkConf() {
-    this.set("spark.spline.x.y", "foo")
-    this.set("spark.spline.w.z", "bar")
-    this.set("spark.spline.xs", "a,b,c")
-  })
+trait MapLikeConfigurationAdapter {
+  this: ReadOnlyConfiguration =>
 
-  override protected val emptyConf = new SparkConfiguration(new SparkConf() {
-    override def getAll: Array[(String, String)] = Array.empty
-  })
+  private val mapConf = new MapConfiguration(propertiesMap)
+
+  protected def propertiesMap: util.Map[String, _ <: AnyRef]
+
+  override def getProperty(key: String): AnyRef = mapConf.getProperty(key)
+
+  override def getKeys: util.Iterator[_] = mapConf.getKeys()
+
+  override def containsKey(key: String): Boolean = mapConf.containsKey(key)
+
+  override def isEmpty: Boolean = mapConf.isEmpty
+
 }

--- a/core/src/main/scala/za/co/absa/spline/harvester/conf/SparkConfiguration.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/conf/SparkConfiguration.scala
@@ -16,34 +16,26 @@
 
 package za.co.absa.spline.harvester.conf
 
-import java.util
-
 import org.apache.spark.SparkConf
 
+import java.util
 import scala.collection.JavaConverters._
-
 
 /**
  * {@link org.apache.spark.SparkConf} to {@link org.apache.commons.configuration.Configuration} adapter
  *
  * @param conf A source of Spark configuration
  */
-class SparkConfiguration(conf: SparkConf) extends ReadOnlyConfiguration {
+class SparkConfiguration(conf: SparkConf)
+  extends ReadOnlyConfiguration
+    with MapLikeConfigurationAdapter {
 
   import SparkConfiguration._
 
-  override def getProperty(key: String): AnyRef =
-    try
-      conf get s"$KEY_PREFIX$key"
-    catch {
-      case _: NoSuchElementException => null
-    }
-
-  override def getKeys: util.Iterator[String] = conf.getAll.iterator.map(_._1.drop(KEY_PREFIX.length)).asJava
-
-  override def containsKey(key: String): Boolean = conf contains s"$KEY_PREFIX$key"
-
-  override def isEmpty: Boolean = conf.getAll.isEmpty
+  override protected def propertiesMap: util.Map[String, _ <: AnyRef] = conf.getAll
+    .map { case (k, v) => k.stripPrefix(KEY_PREFIX) -> v }
+    .toMap
+    .asJava
 }
 
 object SparkConfiguration {

--- a/core/src/test/resources/za/co/absa/spline/harvester/conf/hdfs-test-conf.xml
+++ b/core/src/test/resources/za/co/absa/spline/harvester/conf/hdfs-test-conf.xml
@@ -31,4 +31,10 @@
         <description>test property spline.w.z</description>
     </property>
 
+    <property>
+        <name>spline.xs</name>
+        <value>a,b,c</value>
+        <description>test array property</description>
+    </property>
+
 </configuration>

--- a/core/src/test/scala/za/co/absa/spline/harvester/conf/ReadOnlyConfigurationTest.scala
+++ b/core/src/test/scala/za/co/absa/spline/harvester/conf/ReadOnlyConfigurationTest.scala
@@ -19,6 +19,8 @@ package za.co.absa.spline.harvester.conf
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
+import java.util
+
 trait ReadOnlyConfigurationTest extends AnyFunSuite with Matchers {
   protected val givenConf: ReadOnlyConfiguration
   protected val emptyConf: ReadOnlyConfiguration
@@ -26,13 +28,27 @@ trait ReadOnlyConfigurationTest extends AnyFunSuite with Matchers {
   test("testContainsKey") {
     givenConf containsKey "spline.x.y" shouldBe true
     givenConf containsKey "spline.w.z" shouldBe true
+    givenConf containsKey "spline.xs" shouldBe true
     givenConf containsKey "non-existent" shouldBe false
   }
 
   test("testGetProperty") {
     givenConf getProperty "spline.x.y" shouldEqual "foo"
     givenConf getProperty "spline.w.z" shouldEqual "bar"
+    givenConf getProperty "spline.xs" should be(a[util.List[String]])
     givenConf getProperty "non-existent" shouldBe null
+  }
+
+  test("testGetStringArray") {
+    val xs: Array[String] = givenConf.getStringArray("spline.xs")
+    xs should not be null
+    xs should contain theSameElementsInOrderAs Seq("a", "b", "c")
+  }
+
+  test("testGetList") {
+    val xs: util.List[_] = givenConf.getList("spline.xs")
+    xs should not be null
+    xs should contain theSameElementsInOrderAs Seq("a", "b", "c")
   }
 
   test("testIsEmpty") {
@@ -44,6 +60,7 @@ trait ReadOnlyConfigurationTest extends AnyFunSuite with Matchers {
     import scala.collection.JavaConverters._
     (givenConf getKeys "spline.x").asScala.toSeq should contain("spline.x.y")
     (givenConf getKeys "spline.x").asScala.toSeq shouldNot contain("spline.w.z")
+    (givenConf getKeys "spline.x").asScala.toSeq shouldNot contain("spline.xs")
     (givenConf getKeys "non-existent").asScala shouldBe empty
   }
 }


### PR DESCRIPTION
Make `SparkConfiguration` and `HadoopConfiguration` to behave as `MapConfiguration` with respect to multi-value properties treatment.