### PR TITLE
issue #376 pass Spark Session via arguments instead of Configuration

### DIFF
--- a/core/src/main/scala/za/co/absa/spline/harvester/conf/DefaultSplineConfigurer.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/conf/DefaultSplineConfigurer.scala
@@ -16,7 +16,7 @@
 
 package za.co.absa.spline.harvester.conf
 
-import org.apache.commons.configuration.{CompositeConfiguration, Configuration, MapConfiguration, PropertiesConfiguration}
+import org.apache.commons.configuration.{CompositeConfiguration, Configuration, PropertiesConfiguration}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import za.co.absa.commons.HierarchicalObjectFactory
@@ -90,11 +90,15 @@ class DefaultSplineConfigurer(sparkSession: SparkSession, userConfiguration: Con
   private val configuration = new CompositeConfiguration(Seq(
     userConfiguration,
     new Spline05ConfigurationAdapter(userConfiguration),
-    new PropertiesConfiguration(defaultPropertiesFileName),
-    new MapConfiguration(Map("spline.lineageDispatcher.kafka.sparkSession" -> sparkSession).asJava)
+    new PropertiesConfiguration(defaultPropertiesFileName)
   ).asJava)
 
-  private val objectFactory = new HierarchicalObjectFactory(configuration)
+  private val objectFactory = new HierarchicalObjectFactory(
+    configuration,
+    Seq(
+      classOf[SparkSession] -> sparkSession
+    )
+  )
 
   val splineMode: SplineMode = {
     val modeName = configuration.getRequiredString(Mode)

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/KafkaLineageDispatcher.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/KafkaLineageDispatcher.scala
@@ -39,10 +39,10 @@ class KafkaLineageDispatcher(topic: String, producerProperties: Properties, spar
   extends LineageDispatcher
     with Logging {
 
-  def this(configuration: Configuration) = this(
+  def this(configuration: Configuration, sparkSession: SparkSession) = this(
     configuration.getRequiredString(TopicKey),
     ConfigurationConverter.getProperties(configuration.subset(ProducerKey)),
-    configuration.getProperty("sparkSession").asInstanceOf[SparkSession]
+    sparkSession
   )
 
   logInfo(s"Kafka topic: $topic")

--- a/core/src/test/scala/za/co/absa/commons/HierarchicalObjectFactorySpec.scala
+++ b/core/src/test/scala/za/co/absa/commons/HierarchicalObjectFactorySpec.scala
@@ -20,7 +20,7 @@ import org.apache.commons.configuration.{Configuration, MapConfiguration}
 import org.scalatest.Inside.inside
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import za.co.absa.commons.HierarchicalObjectFactorySpec.{BarComponent, DummyComponenet, FooComponent}
+import za.co.absa.commons.HierarchicalObjectFactorySpec.{BarComponent, DummyComponenet, Foo2Arg, Foo2Component, FooComponent}
 
 class HierarchicalObjectFactorySpec extends AnyFlatSpec with Matchers {
 
@@ -28,18 +28,24 @@ class HierarchicalObjectFactorySpec extends AnyFlatSpec with Matchers {
     val rootObjFactory =
       new HierarchicalObjectFactory(
         new MapConfiguration(new java.util.HashMap[String, AnyRef] {
-          put("test.child.names", "foo, bar")
+          put("test.child.names", "foo, foo2, bar")
           put("foo.className", classOf[FooComponent].getName)
+          put("foo2.className", classOf[Foo2Component].getName)
           put("bar.className", classOf[BarComponent].getName)
-        })
+        }),
+        Seq(
+          classOf[Foo2Arg] -> new Foo2Arg(42)
+        )
       ).child("test")
 
     val subDispatchers = rootObjFactory.createComponentsByKey[DummyComponenet]("child.names")
 
-    subDispatchers should have length 2
+    subDispatchers should have length 3
     inside(subDispatchers) {
-      case Seq(FooComponent(fooConf), BarComponent(barObjFactory)) =>
+      case Seq(FooComponent(fooConf), Foo2Component(foo2Conf, foo2Arg), BarComponent(barObjFactory)) =>
         fooConf.getString("className") should equal(classOf[FooComponent].getName)
+        foo2Conf.getString("className") should equal(classOf[Foo2Component].getName)
+        foo2Arg.x should equal(42)
         barObjFactory.configuration.getString("className") should equal(classOf[BarComponent].getName)
     }
   }
@@ -51,6 +57,10 @@ object HierarchicalObjectFactorySpec {
   trait DummyComponenet
 
   case class FooComponent(conf: Configuration) extends DummyComponenet
+
+  class Foo2Arg(val x: Int)
+
+  case class Foo2Component(conf: Configuration, foo2arg: Foo2Arg) extends DummyComponenet
 
   case class BarComponent(objectFactory: HierarchicalObjectFactory) extends DummyComponenet
 


### PR DESCRIPTION
Suggestion: pass SparkSession as an argument rather than a configuration parameter.
Reasoning: Configuration instance represents a subset of configuration properties that a local to the given component and thus are tied to its logical name, that is unknown to the DefaultConfigurer class. So instead we need to pass the session instance as a parameter with a visibility scope wider than the local component config