### PR TITLE
issue #410 Fix file name collision on case-insensitive filesystems

### DIFF
--- a/core/src/main/scala/za/co/absa/spline/agent/SplineAgent.scala
+++ b/core/src/main/scala/za/co/absa/spline/agent/SplineAgent.scala
@@ -31,7 +31,7 @@ import za.co.absa.spline.harvester.iwd.IgnoredWriteDetectionStrategy
 import za.co.absa.spline.harvester.plugin.registry.AutoDiscoveryPluginRegistry
 import za.co.absa.spline.harvester.postprocessing.{AttributeReorderingFilter, OneRowRelationFilter, PostProcessingFilter, PostProcessor}
 import za.co.absa.spline.harvester.qualifier.HDFSPathQualifier
-import za.co.absa.spline.harvester.{HarvestingContext, IdGenerators, LineageHarvester}
+import za.co.absa.spline.harvester.{HarvestingContext, IdGeneratorsBundle, LineageHarvester}
 import za.co.absa.spline.producer.model.ExecutionPlan
 
 import scala.concurrent.duration.Duration
@@ -63,7 +63,7 @@ object SplineAgent extends Logging {
 
     new SplineAgent {
       def handle(qe: QueryExecution, result: Either[Throwable, Duration]): Unit = withErrorHandling {
-        val idGenerators = new IdGenerators(execPlanUUIDGeneratorFactory)
+        val idGenerators = new IdGeneratorsBundle(execPlanUUIDGeneratorFactory)
         val harvestingContext = new HarvestingContext(qe.analyzed, Some(qe.executedPlan), session, idGenerators)
         val postProcessor = new PostProcessor(filters, harvestingContext)
         val dataTypeConverter = new DataTypeConverter(idGenerators.dataTypeIdGenerator) with CachingConverter

--- a/core/src/main/scala/za/co/absa/spline/harvester/HarvestingContext.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/HarvestingContext.scala
@@ -24,5 +24,5 @@ class HarvestingContext(
   val logicalPlan: LogicalPlan,
   val executedPlanOpt: Option[SparkPlan],
   val session: SparkSession,
-  val idGenerators: IdGenerators
+  val idGenerators: IdGeneratorsBundle
 )

--- a/core/src/main/scala/za/co/absa/spline/harvester/IdGeneratorsBundle.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/IdGeneratorsBundle.scala
@@ -17,12 +17,12 @@
 package za.co.absa.spline.harvester
 
 import za.co.absa.spline.harvester.IdGenerator._
-import za.co.absa.spline.harvester.IdGenerators._
+import za.co.absa.spline.harvester.IdGeneratorsBundle._
 import za.co.absa.spline.producer.model.ExecutionPlan
 
 import java.util.UUID
 
-class IdGenerators(execPlanUUIDGeneratorFactory: UUIDGeneratorFactory[UUIDNamespace, ExecutionPlan]) {
+class IdGeneratorsBundle(execPlanUUIDGeneratorFactory: UUIDGeneratorFactory[UUIDNamespace, ExecutionPlan]) {
   val execPlanIdGenerator: IdGenerator[ExecutionPlan, UUID] = execPlanUUIDGeneratorFactory(UUIDNamespace.ExecutionPlan)
   val attributeIdGenerator: IdGenerator[Any, String] = new SequentialIdGenerator(AttributeIdTemplate)
   val expressionIdGenerator: IdGenerator[Any, String] = new SequentialIdGenerator(ExpressionIdTemplate)
@@ -34,7 +34,7 @@ class IdGenerators(execPlanUUIDGeneratorFactory: UUIDGeneratorFactory[UUIDNamesp
     )
 }
 
-object IdGenerators {
+object IdGeneratorsBundle {
   val AttributeIdTemplate = "attr-{0}"
   val ExpressionIdTemplate = "expr-{0}"
   val OperationIdTemplate = "op-{0}"

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/AggregateNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/AggregateNodeBuilder.scala
@@ -18,13 +18,13 @@ package za.co.absa.spline.harvester.builder
 
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, Expression}
 import org.apache.spark.sql.catalyst.plans.logical.Aggregate
-import za.co.absa.spline.harvester.IdGenerators
+import za.co.absa.spline.harvester.IdGeneratorsBundle
 import za.co.absa.spline.harvester.converter.{DataConverter, DataTypeConverter}
 import za.co.absa.spline.harvester.postprocessing.PostProcessor
 
 class AggregateNodeBuilder
   (operation: Aggregate)
-  (idGenerators: IdGenerators, dataTypeConverter: DataTypeConverter, dataConverter: DataConverter, postProcessor: PostProcessor)
+  (idGenerators: IdGeneratorsBundle, dataTypeConverter: DataTypeConverter, dataConverter: DataConverter, postProcessor: PostProcessor)
   extends GenericNodeBuilder(operation)(idGenerators, dataTypeConverter, dataConverter, postProcessor) {
 
   override def resolveAttributeChild(attribute: Attribute): Option[Expression] = {

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/GenerateNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/GenerateNodeBuilder.scala
@@ -18,13 +18,13 @@ package za.co.absa.spline.harvester.builder
 
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.catalyst.plans.logical.Generate
-import za.co.absa.spline.harvester.IdGenerators
+import za.co.absa.spline.harvester.IdGeneratorsBundle
 import za.co.absa.spline.harvester.converter.{DataConverter, DataTypeConverter}
 import za.co.absa.spline.harvester.postprocessing.PostProcessor
 
 class GenerateNodeBuilder
 (override val operation: Generate)
-  (override val idGenerators: IdGenerators, dataTypeConverter: DataTypeConverter, dataConverter: DataConverter, postProcessor: PostProcessor)
+  (override val idGenerators: IdGeneratorsBundle, dataTypeConverter: DataTypeConverter, dataConverter: DataConverter, postProcessor: PostProcessor)
   extends GenericNodeBuilder(operation)(idGenerators, dataTypeConverter, dataConverter, postProcessor) {
 
   override def resolveAttributeChild(attribute: Attribute): Option[Expression] =

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/GenericNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/GenericNodeBuilder.scala
@@ -18,14 +18,14 @@ package za.co.absa.spline.harvester.builder
 
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import za.co.absa.commons.lang.OptionImplicits._
-import za.co.absa.spline.harvester.IdGenerators
+import za.co.absa.spline.harvester.IdGeneratorsBundle
 import za.co.absa.spline.harvester.converter.{DataConverter, DataTypeConverter, OperationParamsConverter}
 import za.co.absa.spline.harvester.postprocessing.PostProcessor
 import za.co.absa.spline.producer.model.DataOperation
 
 class GenericNodeBuilder
   (val operation: LogicalPlan)
-  (val idGenerators: IdGenerators, val dataTypeConverter: DataTypeConverter, val dataConverter: DataConverter, postProcessor: PostProcessor)
+  (val idGenerators: IdGeneratorsBundle, val dataTypeConverter: DataTypeConverter, val dataConverter: DataConverter, postProcessor: PostProcessor)
   extends OperationNodeBuilder {
 
   override protected type R = DataOperation

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/JoinNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/JoinNodeBuilder.scala
@@ -18,14 +18,14 @@ package za.co.absa.spline.harvester.builder
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.plans.logical.Join
-import za.co.absa.spline.harvester.IdGenerators
+import za.co.absa.spline.harvester.IdGeneratorsBundle
 import za.co.absa.spline.harvester.converter.{DataConverter, DataTypeConverter}
 import za.co.absa.spline.harvester.postprocessing.PostProcessor
 import za.co.absa.spline.producer.model.DataOperation
 
 class JoinNodeBuilder
   (operation: Join)
-  (idGenerators: IdGenerators, dataTypeConverter: DataTypeConverter, dataConverter: DataConverter, postProcessor: PostProcessor)
+  (idGenerators: IdGeneratorsBundle, dataTypeConverter: DataTypeConverter, dataConverter: DataConverter, postProcessor: PostProcessor)
   extends GenericNodeBuilder(operation)(idGenerators, dataTypeConverter, dataConverter, postProcessor) with Logging {
 
   override def build(): DataOperation = {

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/OperationNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/OperationNodeBuilder.scala
@@ -19,7 +19,7 @@ package za.co.absa.spline.harvester.builder
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.{expressions => sparkExprssions}
 import za.co.absa.commons.lang.CachingConverter
-import za.co.absa.spline.harvester.IdGenerators
+import za.co.absa.spline.harvester.IdGeneratorsBundle
 import za.co.absa.spline.harvester.builder.OperationNodeBuilder.OperationId
 import za.co.absa.spline.harvester.converter._
 import za.co.absa.spline.producer.model.{Attribute, FunctionalExpression, Literal}
@@ -38,7 +38,7 @@ trait OperationNodeBuilder {
   protected def resolveAttributeChild(attribute: sparkExprssions.Attribute): Option[sparkExprssions.Expression] = None
 
   protected def inputAttributes: Seq[Seq[Attribute]] = childBuilders.map(_.outputAttributes)
-  protected def idGenerators: IdGenerators
+  protected def idGenerators: IdGeneratorsBundle
   protected def dataTypeConverter: DataTypeConverter
   protected def dataConverter: DataConverter
 

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/OperationNodeBuilderFactory.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/OperationNodeBuilderFactory.scala
@@ -17,7 +17,7 @@
 package za.co.absa.spline.harvester.builder
 
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Generate, Join, LogicalPlan, Project, Union, Window}
-import za.co.absa.spline.harvester.IdGenerators
+import za.co.absa.spline.harvester.IdGeneratorsBundle
 import za.co.absa.spline.harvester.builder.read.{ReadCommand, ReadNodeBuilder}
 import za.co.absa.spline.harvester.builder.write.{WriteCommand, WriteNodeBuilder}
 import za.co.absa.spline.harvester.converter.{DataConverter, DataTypeConverter}
@@ -27,7 +27,7 @@ class OperationNodeBuilderFactory(
   postProcessor: PostProcessor,
   dataTypeConverter: DataTypeConverter,
   dataConverter: DataConverter,
-  idGenerators: IdGenerators
+  idGenerators: IdGeneratorsBundle
 ) {
   def writeNodeBuilder(wc: WriteCommand): WriteNodeBuilder =
     new WriteNodeBuilder(wc)(idGenerators, dataTypeConverter, dataConverter, postProcessor)

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/ProjectNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/ProjectNodeBuilder.scala
@@ -18,13 +18,13 @@ package za.co.absa.spline.harvester.builder
 
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, Expression}
 import org.apache.spark.sql.catalyst.plans.logical.Project
-import za.co.absa.spline.harvester.IdGenerators
+import za.co.absa.spline.harvester.IdGeneratorsBundle
 import za.co.absa.spline.harvester.converter.{DataConverter, DataTypeConverter}
 import za.co.absa.spline.harvester.postprocessing.PostProcessor
 
 class ProjectNodeBuilder
   (operation: Project)
-  (idGenerators: IdGenerators, dataTypeConverter: DataTypeConverter, dataConverter: DataConverter, postProcessor: PostProcessor)
+  (idGenerators: IdGeneratorsBundle, dataTypeConverter: DataTypeConverter, dataConverter: DataConverter, postProcessor: PostProcessor)
   extends GenericNodeBuilder(operation)(idGenerators, dataTypeConverter, dataConverter, postProcessor) {
 
   override def resolveAttributeChild(attribute: Attribute): Option[Expression] = {

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/UnionNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/UnionNodeBuilder.scala
@@ -19,7 +19,7 @@ package za.co.absa.spline.harvester.builder
 import org.apache.spark.sql.catalyst.plans.logical.Union
 import org.apache.spark.sql.catalyst.{expressions => sparkExprssions}
 import za.co.absa.commons.lang.OptionImplicits._
-import za.co.absa.spline.harvester.IdGenerators
+import za.co.absa.spline.harvester.IdGeneratorsBundle
 import za.co.absa.spline.harvester.builder.UnionNodeBuilder._
 import za.co.absa.spline.harvester.converter.{DataConverter, DataTypeConverter}
 import za.co.absa.spline.harvester.postprocessing.PostProcessor
@@ -27,7 +27,7 @@ import za.co.absa.spline.producer.model.{AttrOrExprRef, Attribute, FunctionalExp
 
 class UnionNodeBuilder
 (override val operation: Union)
-  (idGenerators: IdGenerators, dataTypeConverter: DataTypeConverter, dataConverter: DataConverter, postProcessor: PostProcessor)
+  (idGenerators: IdGeneratorsBundle, dataTypeConverter: DataTypeConverter, dataConverter: DataConverter, postProcessor: PostProcessor)
   extends GenericNodeBuilder(operation)(idGenerators, dataTypeConverter, dataConverter, postProcessor) {
 
   private lazy val unionInputs: Seq[Seq[Attribute]] = inputAttributes.transpose

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/WindowNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/WindowNodeBuilder.scala
@@ -19,13 +19,13 @@ package za.co.absa.spline.harvester.builder
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, NamedExpression}
 import org.apache.spark.sql.catalyst.plans.logical.Window
 import za.co.absa.commons.reflect.extractors.AccessorMethodValueExtractor
-import za.co.absa.spline.harvester.IdGenerators
+import za.co.absa.spline.harvester.IdGeneratorsBundle
 import za.co.absa.spline.harvester.converter.{DataConverter, DataTypeConverter}
 import za.co.absa.spline.harvester.postprocessing.PostProcessor
 
 class WindowNodeBuilder
   (operation: Window)
-  (idGenerators: IdGenerators, dataTypeConverter: DataTypeConverter, dataConverter: DataConverter, postProcessor: PostProcessor)
+  (idGenerators: IdGeneratorsBundle, dataTypeConverter: DataTypeConverter, dataConverter: DataConverter, postProcessor: PostProcessor)
   extends GenericNodeBuilder(operation)(idGenerators, dataTypeConverter, dataConverter, postProcessor) {
 
   override def resolveAttributeChild(attribute: Attribute): Option[Expression] = {

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/read/ReadNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/read/ReadNodeBuilder.scala
@@ -18,7 +18,7 @@ package za.co.absa.spline.harvester.builder.read
 
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import za.co.absa.commons.lang.OptionImplicits._
-import za.co.absa.spline.harvester.IdGenerators
+import za.co.absa.spline.harvester.IdGeneratorsBundle
 import za.co.absa.spline.harvester.ModelConstants.OperationExtras
 import za.co.absa.spline.harvester.builder.OperationNodeBuilder
 import za.co.absa.spline.harvester.converter.{DataConverter, DataTypeConverter, IOParamsConverter}
@@ -27,7 +27,7 @@ import za.co.absa.spline.producer.model.ReadOperation
 
 class ReadNodeBuilder
   (val command: ReadCommand)
-  (val idGenerators: IdGenerators, val dataTypeConverter: DataTypeConverter, val dataConverter: DataConverter, postProcessor: PostProcessor)
+  (val idGenerators: IdGeneratorsBundle, val dataTypeConverter: DataTypeConverter, val dataConverter: DataConverter, postProcessor: PostProcessor)
   extends OperationNodeBuilder {
 
   override protected type R = ReadOperation

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/write/WriteNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/write/WriteNodeBuilder.scala
@@ -19,7 +19,7 @@ package za.co.absa.spline.harvester.builder.write
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import za.co.absa.commons.lang.OptionImplicits._
-import za.co.absa.spline.harvester.IdGenerators
+import za.co.absa.spline.harvester.IdGeneratorsBundle
 import za.co.absa.spline.harvester.ModelConstants.OperationExtras
 import za.co.absa.spline.harvester.builder.OperationNodeBuilder
 import za.co.absa.spline.harvester.converter.{DataConverter, DataTypeConverter, IOParamsConverter}
@@ -28,7 +28,7 @@ import za.co.absa.spline.producer.model.{Attribute, WriteOperation}
 
 class WriteNodeBuilder
 (command: WriteCommand)
-  (val idGenerators: IdGenerators, val dataTypeConverter: DataTypeConverter, val dataConverter: DataConverter, postProcessor: PostProcessor)
+  (val idGenerators: IdGeneratorsBundle, val dataTypeConverter: DataTypeConverter, val dataConverter: DataConverter, postProcessor: PostProcessor)
   extends OperationNodeBuilder {
 
   override protected type R = WriteOperation

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/modelmapper/ModelMapperV10.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/modelmapper/ModelMapperV10.scala
@@ -16,7 +16,7 @@
 
 package za.co.absa.spline.harvester.dispatcher.modelmapper
 
-import za.co.absa.spline.harvester.IdGenerators
+import za.co.absa.spline.harvester.IdGeneratorsBundle
 import za.co.absa.spline.harvester.converter.ExpressionConverter.{ExprExtra, ExprV1}
 import za.co.absa.spline.producer.dto.v1_0
 import za.co.absa.spline.producer.model._
@@ -109,7 +109,7 @@ object ModelMapperV10 extends ModelMapper[v1_0.ExecutionPlan, v1_0.ExecutionEven
       )
 
     def toV1OperationId(opIdV11: String): Int = {
-      val Array(opIdV1Str: String) = new MessageFormat(IdGenerators.OperationIdTemplate).parse(opIdV11)
+      val Array(opIdV1Str: String) = new MessageFormat(IdGeneratorsBundle.OperationIdTemplate).parse(opIdV11)
       opIdV1Str.toInt
     }
 

--- a/core/src/test/scala/za/co/absa/spline/harvester/IdGeneratorSpec.scala
+++ b/core/src/test/scala/za/co/absa/spline/harvester/IdGeneratorSpec.scala
@@ -21,8 +21,6 @@ import org.mockito.Mockito._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
-import za.co.absa.spline.harvester.IdGenerator.UUIDGeneratorFactory
-import za.co.absa.spline.producer.model.ExecutionPlan
 
 import java.security.MessageDigest
 import java.util.UUID
@@ -31,22 +29,6 @@ class IdGeneratorSpec
   extends AnyFlatSpec
     with Matchers
     with MockitoSugar {
-
-  behavior of "IdGenerators.dataTypeIdGenerator"
-
-  it should "generate deterministic sequence of unique ID" in {
-
-    val execPlanUUIDGeneratorFactoryMock = mock[UUIDGeneratorFactory[Any, ExecutionPlan]]
-
-    val gen1 = new IdGenerators(execPlanUUIDGeneratorFactoryMock).dataTypeIdGenerator
-    val gen2 = new IdGenerators(execPlanUUIDGeneratorFactoryMock).dataTypeIdGenerator
-
-    val seq1 = (1 to 10).map(_ => gen1.nextId())
-    val seq2 = (1 to 10).map(_ => gen2.nextId())
-
-    seq1 shouldEqual seq2
-    seq1.distinct.length shouldBe 10
-  }
 
   behavior of "ComposableIdGenerator"
 

--- a/core/src/test/scala/za/co/absa/spline/harvester/IdGeneratorsBundleSpec.scala
+++ b/core/src/test/scala/za/co/absa/spline/harvester/IdGeneratorsBundleSpec.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.spline.harvester
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+import za.co.absa.spline.harvester.IdGenerator.UUIDGeneratorFactory
+import za.co.absa.spline.producer.model.ExecutionPlan
+
+class IdGeneratorsBundleSpec
+  extends AnyFlatSpec
+    with Matchers
+    with MockitoSugar {
+
+  behavior of "dataTypeIdGenerator"
+
+  it should "generate deterministic sequence of unique ID" in {
+
+    val execPlanUUIDGeneratorFactoryMock = mock[UUIDGeneratorFactory[Any, ExecutionPlan]]
+
+    val gen1 = new IdGeneratorsBundle(execPlanUUIDGeneratorFactoryMock).dataTypeIdGenerator
+    val gen2 = new IdGeneratorsBundle(execPlanUUIDGeneratorFactoryMock).dataTypeIdGenerator
+
+    val seq1 = (1 to 10).map(_ => gen1.nextId())
+    val seq2 = (1 to 10).map(_ => gen2.nextId())
+
+    seq1 shouldEqual seq2
+    seq1.distinct.length shouldBe 10
+  }
+
+}

--- a/core/src/test/scala/za/co/absa/spline/harvester/builder/BuilderSpec.scala
+++ b/core/src/test/scala/za/co/absa/spline/harvester/builder/BuilderSpec.scala
@@ -23,7 +23,7 @@ import org.mockito.Mockito.when
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
-import za.co.absa.spline.harvester.{IdGenerator, IdGenerators}
+import za.co.absa.spline.harvester.{IdGenerator, IdGeneratorsBundle}
 import za.co.absa.spline.harvester.builder.read.{ReadCommand, ReadNodeBuilder}
 import za.co.absa.spline.harvester.converter.{DataConverter, DataTypeConverter}
 import za.co.absa.spline.harvester.postprocessing.PostProcessor
@@ -37,7 +37,7 @@ class BuilderSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     val dataTypeConverterMock = mock[DataTypeConverter]
     val dataConverterMock = mock[DataConverter]
 
-    val idGeneratorsMock = mock[IdGenerators]
+    val idGeneratorsMock = mock[IdGeneratorsBundle]
     val operationIdGeneratorMock = mock[IdGenerator[Any, String]]
 
     when(logicalPlanStub.output) thenReturn Seq.empty

--- a/core/src/test/scala/za/co/absa/spline/harvester/postprocessing/extra/MetadataCollectingFilterSpec.scala
+++ b/core/src/test/scala/za/co/absa/spline/harvester/postprocessing/extra/MetadataCollectingFilterSpec.scala
@@ -25,7 +25,7 @@ import org.scalatestplus.mockito.MockitoSugar
 import za.co.absa.commons.scalatest.EnvFixture
 import za.co.absa.spline.harvester.postprocessing.metadata.MetadataCollectingFilter._
 import za.co.absa.spline.harvester.postprocessing.metadata.{BaseNodeName, MetadataCollectingFilter}
-import za.co.absa.spline.harvester.{HarvestingContext, IdGenerators}
+import za.co.absa.spline.harvester.{HarvestingContext, IdGeneratorsBundle}
 import za.co.absa.spline.producer.model._
 
 import java.util.UUID
@@ -39,7 +39,7 @@ class MetadataCollectingFilterSpec extends AnyFlatSpec with EnvFixture with Matc
     .config("k", "nice")
     .getOrCreate()
 
-  private val idGenerators = mock[IdGenerators]
+  private val idGenerators = mock[IdGeneratorsBundle]
   private val harvestingContext = new HarvestingContext(logicalPlan, None, sparkSession, idGenerators)
 
   private val wop = WriteOperation("foo", append = false, "42", None, Seq.empty, None, None)


### PR DESCRIPTION
- Rename `IdGenerators` to `IdGeneratorsBundle`
- Extract `IdGeneratorsBundle` related test case from `IdGeneratorSpec` into a new `IdGeneratorsBundleSpec`
