### PR TITLE
spark agent #408 fix ObjectStructureDumper exception log bug

### DIFF
--- a/core/src/main/scala/za/co/absa/commons/ThrowableImplicits.scala
+++ b/core/src/main/scala/za/co/absa/commons/ThrowableImplicits.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons
+
+object ThrowableImplicits {
+
+  implicit class ThrowableOps(val e: Throwable) extends AnyVal {
+
+    def toShortString: String = {
+      val stackTrace = e.getStackTrace
+
+      if (stackTrace != null && stackTrace.nonEmpty)
+        s"${e.getMessage} at ${stackTrace(0)}"
+      else
+        s"${e.getMessage} (no stack trace available)"
+    }
+
+  }
+}

--- a/core/src/main/scala/za/co/absa/spline/harvester/logging/ObjectStructureDumper.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/logging/ObjectStructureDumper.scala
@@ -16,10 +16,12 @@
 
 package za.co.absa.spline.harvester.logging
 
+import za.co.absa.commons.ThrowableImplicits._
 import za.co.absa.commons.reflect.ReflectionUtils
 
 import java.lang.reflect.Modifier
 import scala.annotation.tailrec
+import scala.util.Random
 import scala.util.control.NonFatal
 
 object ObjectStructureDumper {
@@ -94,7 +96,7 @@ object ObjectStructureDumper {
                 try {
                   extractFieldValue(value, f.getName)
                 } catch {
-                  case NonFatal(e) => s"! error occurred: ${e.getMessage} at ${e.getStackTrace()(0)}"
+                  case NonFatal(e) => s"! error occurred: ${e.toShortString}"
                 }
               ObjectBox(subValue, f.getName, f.getType.getName, depth + 1)
             }.toList
@@ -119,9 +121,13 @@ object ObjectStructureDumper {
 
   private def isReadyForPrint(value: AnyRef): Boolean = {
     isPrimitiveLike(value) ||
-      Set("String")(value.getClass.getSimpleName) ||
+      value.isInstanceOf[java.lang.CharSequence]  ||
       value.isInstanceOf[Traversable[_]] ||
-      value.isInstanceOf[Enum[_]]
+      value.isInstanceOf[Enum[_]] ||
+      value.isInstanceOf[java.util.Random] ||
+      value.isInstanceOf[Random] ||
+      value.isInstanceOf[java.lang.Number] ||
+      value.isInstanceOf[Numeric[_]]
   }
 
   private def isPrimitiveLike(value: Any): Boolean = {

--- a/core/src/test/scala/za/co/absa/spline/harvester/logging/ObjectStructureDumperSpec.scala
+++ b/core/src/test/scala/za/co/absa/spline/harvester/logging/ObjectStructureDumperSpec.scala
@@ -22,6 +22,9 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import za.co.absa.spline.harvester.logging.ObjectStructureDumper.ExtractFieldValueFn
 
+import java.util.concurrent.atomic.AtomicInteger
+import scala.util.Random
+
 class ObjectStructureDumperSpec extends AnyFlatSpec with Matchers with MockitoSugar {
 
   behavior of "dump()"
@@ -54,5 +57,11 @@ class ObjectStructureDumperSpec extends AnyFlatSpec with Matchers with MockitoSu
       should (include("bar: java.lang.String = null")
       and include("baz: java.lang.String = ! error occurred: fake at za.co.absa.spline.harvester.logging.ObjectStructureDumper")
       ))
+  }
+
+  it should "not fail on numbers and Random" in {
+    ObjectStructureDumper.dump(new java.util.Random()) should include("java.util.Random")
+    ObjectStructureDumper.dump(new Random()) should include("scala.util.Random")
+    ObjectStructureDumper.dump(new AtomicInteger(42)) should include("java.util.concurrent.atomic.AtomicInteger")
   }
 }


### PR DESCRIPTION
- avoid exception when stack trace not present / null
- avoid infinite cycle when dumping Random
- additional types to print immediately