### PR TITLE
Bugfix/spline spark agent 417 read timeout

### DIFF
--- a/core/src/main/resources/spline.default.properties
+++ b/core/src/main/resources/spline.default.properties
@@ -34,6 +34,8 @@ spline.lineageDispatcher=http
 spline.lineageDispatcher.http.className=za.co.absa.spline.harvester.dispatcher.HttpLineageDispatcher
 # Base URL of the Spline Producer REST API endpoint
 spline.lineageDispatcher.http.producer.url=
+spline.lineageDispatcher.http.timeout.connection=2000
+spline.lineageDispatcher.http.timeout.read=120000
 
 # Kafka dispatcher
 spline.lineageDispatcher.kafka.className=za.co.absa.spline.harvester.dispatcher.KafkaLineageDispatcher
@@ -69,7 +71,7 @@ spline.lineageDispatcher.hdfs.fileName=_LINEAGE
 # the size of the buffer to be used
 spline.lineageDispatcher.hdfs.fileBufferSize=4096
 # file/directory permissions, provided as umask string, either in octal or symbolic format
-spline.lineageDispatcher.hdfs.filePermissions=
+spline.lineageDispatcher.hdfs.filePermissions=777
 
 
 

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/HDFSLineageDispatcher.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/HDFSLineageDispatcher.scala
@@ -49,7 +49,7 @@ class HDFSLineageDispatcher(filename: String, permission: FsPermission, bufferSi
 
   def this(conf: Configuration) = this(
     filename = conf.getRequiredString(FileNameKey),
-    permission = new FsPermission(conf.getOptionalString(FilePermissionsKey).getOrElse(DefaultFilePermission.toShort.toString)),
+    permission = new FsPermission(conf.getRequiredString(FilePermissionsKey)),
     bufferSize = conf.getRequiredInt(BufferSizeKey)
   )
 
@@ -104,8 +104,6 @@ object HDFSLineageDispatcher {
   private val FilePermissionsKey = "filePermissions"
   private val BufferSizeKey = "fileBufferSize"
 
-  private val DefaultFilePermission = new FsPermission("777")
-
   /**
    * Converts string full path to Hadoop FS and Path, e.g.
    * `s3://mybucket1/path/to/file` -> S3 FS + `path/to/file`
@@ -115,7 +113,7 @@ object HDFSLineageDispatcher {
    *
    * @param pathString path to convert to FS and relative path
    * @return FS + relative path
-   **/
+   */
   def pathStringToFsWithPath(pathString: String): (FileSystem, Path) = {
     pathString.toSimpleS3Location match {
       case Some(s3Location) =>

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/HttpLineageDispatcherConfig.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/HttpLineageDispatcherConfig.scala
@@ -27,22 +27,11 @@ object HttpLineageDispatcherConfig {
   val ConnectionTimeoutMsKey = "timeout.connection"
   val ReadTimeoutMsKey = "timeout.read"
 
-  val DefaultConnectionTimeout: Duration = 1.second
-  val DefaultReadTimeout: Duration = 20.second
-
   def apply(c: Configuration) = new HttpLineageDispatcherConfig(c)
 }
 
 class HttpLineageDispatcherConfig(config: Configuration) {
   val producerUrl: String = config.getRequiredString(ProducerUrlProperty)
-
-  val connTimeout: Duration = config
-    .getOptionalLong(ConnectionTimeoutMsKey)
-    .map(_.millis)
-    .getOrElse(DefaultConnectionTimeout)
-
-  val readTimeout: Duration = config
-    .getOptionalLong(ReadTimeoutMsKey)
-    .map(_.millis)
-    .getOrElse(DefaultReadTimeout)
+  val connTimeout: Duration = config.getRequiredLong(ConnectionTimeoutMsKey).millis
+  val readTimeout: Duration = config.getRequiredLong(ReadTimeoutMsKey).millis
 }

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/SplineHttpHeaders.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/SplineHttpHeaders.scala
@@ -22,4 +22,6 @@ object SplineHttpHeaders {
   val ApiVersion = s"$Prefix-API-Version"
   val ApiLTSVersion = s"$Prefix-API-LTS-Version"
   val AcceptRequestEncoding = s"$Prefix-Accept-Request-Encoding"
+
+  val Timeout = "X-SPLINE-TIMEOUT"
 }

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/rest/RestClient.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/rest/RestClient.scala
@@ -18,6 +18,7 @@ package za.co.absa.spline.harvester.dispatcher.httpdispatcher.rest
 
 import org.apache.spark.internal.Logging
 import scalaj.http.BaseHttp
+import za.co.absa.spline.harvester.dispatcher.httpdispatcher.SplineHttpHeaders
 
 import scala.concurrent.duration.Duration
 
@@ -47,6 +48,7 @@ object RestClient extends Logging {
       override def endpoint(resource: String): RestEndpoint = new RestEndpoint(
         baseHttp(s"$baseURL/$resource")
           .timeout(connectionTimeout.toMillis.toInt, readTimeout.toMillis.toInt)
+          .header(SplineHttpHeaders.Timeout, readTimeout.toMillis.toString)
           .compress(true))
     }
   }


### PR DESCRIPTION
- HTTP Dispatcher: Send a `X-SPLINE-TIMEOUT` header along with a Producer REST request to control server side async timeout.
- Refactoring: Move some default config values hard coded in the scala files to the `spline.default.properties`