### PR TITLE
spark agent #137 ObjectStructureDumper will ignore fields of type Class

### DIFF
--- a/core/src/main/scala/za/co/absa/spline/harvester/logging/ObjectStructureDumper.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/logging/ObjectStructureDumper.scala
@@ -19,7 +19,7 @@ package za.co.absa.spline.harvester.logging
 import za.co.absa.commons.ThrowableImplicits._
 import za.co.absa.commons.reflect.ReflectionUtils
 
-import java.lang.reflect.Modifier
+import java.lang.reflect.{Field, Modifier}
 import scala.annotation.tailrec
 import scala.util.Random
 import scala.util.control.NonFatal
@@ -89,8 +89,7 @@ object ObjectStructureDumper {
         }
         case _ => {
           val newFields = value.getClass.getDeclaredFields
-            .filter(f => !Set("child", "session")(f.getName))
-            .filter(f => !Modifier.isStatic(f.getModifiers))
+            .filter(!isIgnoredField(_))
             .map { f =>
               val subValue =
                 try {
@@ -118,6 +117,11 @@ object ObjectStructureDumper {
       objectToStringRec(extractFieldValue)(newStack, newVisited, newResult)
     }
   }
+  private def isIgnoredField(f: Field): Boolean = {
+    Set("child", "session")(f.getName) ||
+      Modifier.isStatic(f.getModifiers) ||
+      Modifier.isTransient(f.getModifiers)
+  }
 
   private def isReadyForPrint(value: AnyRef): Boolean = {
     isPrimitiveLike(value) ||
@@ -127,7 +131,8 @@ object ObjectStructureDumper {
       value.isInstanceOf[java.util.Random] ||
       value.isInstanceOf[Random] ||
       value.isInstanceOf[java.lang.Number] ||
-      value.isInstanceOf[Numeric[_]]
+      value.isInstanceOf[Numeric[_]] ||
+      value.isInstanceOf[Class[_]]
   }
 
   private def isPrimitiveLike(value: Any): Boolean = {

--- a/core/src/test/scala/za/co/absa/spline/harvester/logging/ObjectStructureDumperSpec.scala
+++ b/core/src/test/scala/za/co/absa/spline/harvester/logging/ObjectStructureDumperSpec.scala
@@ -78,4 +78,23 @@ class ObjectStructureDumperSpec extends AnyFlatSpec with Matchers with MockitoSu
     ObjectStructureDumper.dump(new Random()) should include("scala.util.Random")
     ObjectStructureDumper.dump(new AtomicInteger(42)) should include("java.util.concurrent.atomic.AtomicInteger")
   }
+
+  it should "not descend into fields of type of Class[_]" in {
+    case class ClassBox(cl: Class[_])
+
+    val classBoxDump = ObjectStructureDumper.dump(ClassBox(classOf[java.net.URI]))
+    classBoxDump should include("java.net.URI")
+    classBoxDump should not include("canonicalName")
+  }
+
+  it should "ignore transient fields" in {
+    class Foo {
+      @transient lazy val bar = "42"
+    }
+
+    val fooDump = ObjectStructureDumper.dump(new Foo)
+    fooDump should not include("bar")
+    fooDump should not include("42")
+  }
+
 }


### PR DESCRIPTION
- ObjectStructureDumper will ignore transient fields

fixes #137 