### PR TITLE
Feature/agent 33 rdd support

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>za.co.absa.commons</groupId>
             <artifactId>commons_${scala.binary.version}</artifactId>
-            <version>1.0.3</version>
+            <version>1.0.7</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>

--- a/core/src/main/scala/za/co/absa/spline/harvester/LineageHarvester.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/LineageHarvester.scala
@@ -201,10 +201,10 @@ class LineageHarvester(
           // special handling - spark 2.3 sometimes includes AnalysisBarrier in the plan
           val child = ReflectionUtils.extractValue[LogicalPlan](plan, "child")
           Seq(PlanWrap(child))
-        case ExternalRDD(outputObjAttr, rdd) =>
-          Seq(RddWrap(rdd))
-        case LogicalRDD(output, rdd, outputPartitioning, outputOrdering, isStreaming) =>
-          Seq(RddWrap(rdd))
+        case erdd: ExternalRDD[_] =>
+          Seq(RddWrap(erdd.rdd))
+        case lrdd: LogicalRDD =>
+          Seq(RddWrap(lrdd.rdd))
         case _ => plan.children.map(PlanWrap)
       }
     case RddWrap(rdd) =>

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/GenerateNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/GenerateNodeBuilder.scala
@@ -23,10 +23,10 @@ import za.co.absa.spline.harvester.converter.{DataConverter, DataTypeConverter}
 import za.co.absa.spline.harvester.postprocessing.PostProcessor
 
 class GenerateNodeBuilder
-(override val operation: Generate)
+(override val logicalPlan: Generate)
   (override val idGenerators: IdGeneratorsBundle, dataTypeConverter: DataTypeConverter, dataConverter: DataConverter, postProcessor: PostProcessor)
-  extends GenericNodeBuilder(operation)(idGenerators, dataTypeConverter, dataConverter, postProcessor) {
+  extends GenericNodeBuilder(logicalPlan)(idGenerators, dataTypeConverter, dataConverter, postProcessor) {
 
   override def resolveAttributeChild(attribute: Attribute): Option[Expression] =
-    Some(operation.generator)
+    Some(logicalPlan.generator)
 }

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/OperationNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/OperationNodeBuilder.scala
@@ -16,12 +16,9 @@
 
 package za.co.absa.spline.harvester.builder
 
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.{expressions => sparkExprssions}
-import za.co.absa.commons.lang.CachingConverter
 import za.co.absa.spline.harvester.IdGeneratorsBundle
-import za.co.absa.spline.harvester.builder.PlanOperationNodeBuilder.OperationId
-import za.co.absa.spline.harvester.converter._
+import za.co.absa.spline.harvester.builder.plan.PlanOperationNodeBuilder.OperationId
 import za.co.absa.spline.producer.model.{Attribute, FunctionalExpression, Literal}
 
 trait OperationNodeBuilder {

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/OperationNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/OperationNodeBuilder.scala
@@ -20,7 +20,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.{expressions => sparkExprssions}
 import za.co.absa.commons.lang.CachingConverter
 import za.co.absa.spline.harvester.IdGeneratorsBundle
-import za.co.absa.spline.harvester.builder.OperationNodeBuilder.OperationId
+import za.co.absa.spline.harvester.builder.PlanOperationNodeBuilder.OperationId
 import za.co.absa.spline.harvester.converter._
 import za.co.absa.spline.producer.model.{Attribute, FunctionalExpression, Literal}
 
@@ -30,62 +30,22 @@ trait OperationNodeBuilder {
 
   val operationId: OperationId = idGenerators.operationIdGenerator.nextId()
 
-  private var childBuilders: Seq[OperationNodeBuilder] = Nil
+  protected var childBuilders: Seq[OperationNodeBuilder] = Nil
 
-  def operation: LogicalPlan
   def build(): R
   def +=(childBuilder: OperationNodeBuilder): Unit = childBuilders :+= childBuilder
   protected def resolveAttributeChild(attribute: sparkExprssions.Attribute): Option[sparkExprssions.Expression] = None
 
   protected def inputAttributes: Seq[Seq[Attribute]] = childBuilders.map(_.outputAttributes)
   protected def idGenerators: IdGeneratorsBundle
-  protected def dataTypeConverter: DataTypeConverter
-  protected def dataConverter: DataConverter
 
-  protected lazy val attributeConverter =
-    new AttributeConverter(
-      idGenerators.attributeIdGenerator,
-      dataTypeConverter,
-      resolveAttributeChild,
-      childBuilders.map(_.outputExprToAttMap).reduceOption(_ ++ _).getOrElse(Map.empty),
-      exprToRefConverter
-    ) with CachingConverter
-
-  protected lazy val expressionConverter =
-    new ExpressionConverter(
-      idGenerators.expressionIdGenerator,
-      dataTypeConverter,
-      exprToRefConverter
-    ) with CachingConverter
-
-  protected lazy val literalConverter =
-    new LiteralConverter(
-      idGenerators.expressionIdGenerator,
-      dataConverter,
-      dataTypeConverter
-    ) with CachingConverter
-
-  protected lazy val exprToRefConverter: ExprToRefConverter =
-    new ExprToRefConverter(
-      attributeConverter,
-      expressionConverter,
-      literalConverter
-    )
-
-  lazy val outputAttributes: Seq[Attribute] =
-    operation.output.map(attributeConverter.convert)
-
-  private def outputExprToAttMap: Map[sparkExprssions.ExprId, Attribute] =
-    operation.output.map(_.exprId).zip(outputAttributes).toMap
+  def outputAttributes: Seq[Attribute]
 
   def childIds: Seq[OperationId] = childBuilders.map(_.operationId)
 
-  lazy val functionalExpressions: Seq[FunctionalExpression] = expressionConverter.values
+  def functionalExpressions: Seq[FunctionalExpression]
 
-  lazy val literals: Seq[Literal] = literalConverter.values
-}
+  def literals: Seq[Literal]
 
-object OperationNodeBuilder {
-  type OperationId = String
-  type OutputAttIds = Seq[String]
+  def outputExprToAttMap: Map[sparkExprssions.ExprId, Attribute]
 }

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/OperationNodeBuilderFactory.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/OperationNodeBuilderFactory.scala
@@ -20,10 +20,13 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.plans.logical._
 import za.co.absa.spline.harvester.IdGeneratorsBundle
 import za.co.absa.spline.harvester.LineageHarvester.{PlanOrRdd, PlanWrap, RddWrap}
+import za.co.absa.spline.harvester.builder.plan.read.ReadNodeBuilder
+import za.co.absa.spline.harvester.builder.plan.write.WriteNodeBuilder
+import za.co.absa.spline.harvester.builder.plan.{AggregateNodeBuilder, GenerateNodeBuilder, GenericPlanNodeBuilder, JoinNodeBuilder, ProjectNodeBuilder, UnionNodeBuilder, WindowNodeBuilder}
 import za.co.absa.spline.harvester.builder.rdd.GenericRddNodeBuilder
 import za.co.absa.spline.harvester.builder.rdd.read.RddReadNodeBuilder
-import za.co.absa.spline.harvester.builder.read.{ReadCommand, ReadNodeBuilder}
-import za.co.absa.spline.harvester.builder.write.{WriteCommand, WriteNodeBuilder}
+import za.co.absa.spline.harvester.builder.read.ReadCommand
+import za.co.absa.spline.harvester.builder.write.WriteCommand
 import za.co.absa.spline.harvester.converter.{DataConverter, DataTypeConverter}
 import za.co.absa.spline.harvester.postprocessing.PostProcessor
 
@@ -53,7 +56,7 @@ class OperationNodeBuilderFactory(
     case g: Generate => new GenerateNodeBuilder(g)(idGenerators, dataTypeConverter, dataConverter, postProcessor)
     case w: Window => new WindowNodeBuilder(w)(idGenerators, dataTypeConverter, dataConverter, postProcessor)
     case j: Join => new JoinNodeBuilder(j)(idGenerators, dataTypeConverter, dataConverter, postProcessor)
-    case _ => new GenericNodeBuilder(lp)(idGenerators, dataTypeConverter, dataConverter, postProcessor)
+    case _ => new GenericPlanNodeBuilder(lp)(idGenerators, dataTypeConverter, dataConverter, postProcessor)
   }
 
   private def genericRddNodeBuilder(rdd: RDD[_]): OperationNodeBuilder = rdd match {

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/PlanOperationNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/PlanOperationNodeBuilder.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.spline.harvester.builder
+
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.{expressions => sparkExprssions}
+import za.co.absa.commons.lang.CachingConverter
+import za.co.absa.spline.harvester.IdGeneratorsBundle
+import za.co.absa.spline.harvester.converter._
+import za.co.absa.spline.producer.model.{Attribute, FunctionalExpression, Literal}
+
+trait PlanOperationNodeBuilder extends OperationNodeBuilder {
+
+  def logicalPlan: LogicalPlan
+
+  protected def idGenerators: IdGeneratorsBundle
+  protected def dataTypeConverter: DataTypeConverter
+  protected def dataConverter: DataConverter
+
+  protected lazy val attributeConverter =
+    new AttributeConverter(
+      idGenerators.attributeIdGenerator,
+      dataTypeConverter,
+      resolveAttributeChild,
+      childBuilders.map(_.outputExprToAttMap).reduceOption(_ ++ _).getOrElse(Map.empty),
+      exprToRefConverter
+    ) with CachingConverter
+
+  protected lazy val expressionConverter =
+    new ExpressionConverter(
+      idGenerators.expressionIdGenerator,
+      dataTypeConverter,
+      exprToRefConverter
+    ) with CachingConverter
+
+  protected lazy val literalConverter =
+    new LiteralConverter(
+      idGenerators.expressionIdGenerator,
+      dataConverter,
+      dataTypeConverter
+    ) with CachingConverter
+
+  protected lazy val exprToRefConverter: ExprToRefConverter =
+    new ExprToRefConverter(
+      attributeConverter,
+      expressionConverter,
+      literalConverter
+    )
+
+  lazy val outputAttributes: Seq[Attribute] =
+    logicalPlan.output.map(attributeConverter.convert)
+
+  override def outputExprToAttMap: Map[sparkExprssions.ExprId, Attribute] =
+    logicalPlan.output.map(_.exprId).zip(outputAttributes).toMap
+
+  lazy val functionalExpressions: Seq[FunctionalExpression] = expressionConverter.values
+
+  lazy val literals: Seq[Literal] = literalConverter.values
+}
+
+object PlanOperationNodeBuilder {
+  type OperationId = String
+  type OutputAttIds = Seq[String]
+}

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/UnionNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/UnionNodeBuilder.scala
@@ -26,15 +26,15 @@ import za.co.absa.spline.harvester.postprocessing.PostProcessor
 import za.co.absa.spline.producer.model.{AttrOrExprRef, Attribute, FunctionalExpression}
 
 class UnionNodeBuilder
-(override val operation: Union)
+(override val logicalPlan: Union)
   (idGenerators: IdGeneratorsBundle, dataTypeConverter: DataTypeConverter, dataConverter: DataConverter, postProcessor: PostProcessor)
-  extends GenericNodeBuilder(operation)(idGenerators, dataTypeConverter, dataConverter, postProcessor) {
+  extends GenericNodeBuilder(logicalPlan)(idGenerators, dataTypeConverter, dataConverter, postProcessor) {
 
   private lazy val unionInputs: Seq[Seq[Attribute]] = inputAttributes.transpose
 
   override lazy val functionalExpressions: Seq[FunctionalExpression] =
     unionInputs
-      .zip(operation.output)
+      .zip(logicalPlan.output)
       .map { case (input, output) => constructUnionFunction(input, output) }
 
   override lazy val outputAttributes: Seq[Attribute] =

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/AggregateNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/AggregateNodeBuilder.scala
@@ -14,19 +14,22 @@
  * limitations under the License.
  */
 
-package za.co.absa.spline.harvester.builder
+package za.co.absa.spline.harvester.builder.plan
 
-import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
-import org.apache.spark.sql.catalyst.plans.logical.Generate
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, Expression}
+import org.apache.spark.sql.catalyst.plans.logical.Aggregate
 import za.co.absa.spline.harvester.IdGeneratorsBundle
 import za.co.absa.spline.harvester.converter.{DataConverter, DataTypeConverter}
 import za.co.absa.spline.harvester.postprocessing.PostProcessor
 
-class GenerateNodeBuilder
-(override val logicalPlan: Generate)
-  (override val idGenerators: IdGeneratorsBundle, dataTypeConverter: DataTypeConverter, dataConverter: DataConverter, postProcessor: PostProcessor)
-  extends GenericNodeBuilder(logicalPlan)(idGenerators, dataTypeConverter, dataConverter, postProcessor) {
+class AggregateNodeBuilder
+  (operation: Aggregate)
+  (idGenerators: IdGeneratorsBundle, dataTypeConverter: DataTypeConverter, dataConverter: DataConverter, postProcessor: PostProcessor)
+  extends GenericPlanNodeBuilder(operation)(idGenerators, dataTypeConverter, dataConverter, postProcessor) {
 
-  override def resolveAttributeChild(attribute: Attribute): Option[Expression] =
-    Some(logicalPlan.generator)
+  override def resolveAttributeChild(attribute: Attribute): Option[Expression] = {
+    operation.aggregateExpressions
+      .find(_.exprId == attribute.exprId)
+      .map(_.asInstanceOf[Alias])
+  }
 }

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/GenerateNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/GenerateNodeBuilder.scala
@@ -14,22 +14,19 @@
  * limitations under the License.
  */
 
-package za.co.absa.spline.harvester.builder
+package za.co.absa.spline.harvester.builder.plan
 
-import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, Expression}
-import org.apache.spark.sql.catalyst.plans.logical.Project
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+import org.apache.spark.sql.catalyst.plans.logical.Generate
 import za.co.absa.spline.harvester.IdGeneratorsBundle
 import za.co.absa.spline.harvester.converter.{DataConverter, DataTypeConverter}
 import za.co.absa.spline.harvester.postprocessing.PostProcessor
 
-class ProjectNodeBuilder
-  (operation: Project)
-  (idGenerators: IdGeneratorsBundle, dataTypeConverter: DataTypeConverter, dataConverter: DataConverter, postProcessor: PostProcessor)
-  extends GenericNodeBuilder(operation)(idGenerators, dataTypeConverter, dataConverter, postProcessor) {
+class GenerateNodeBuilder
+(override val logicalPlan: Generate)
+  (override val idGenerators: IdGeneratorsBundle, dataTypeConverter: DataTypeConverter, dataConverter: DataConverter, postProcessor: PostProcessor)
+  extends GenericPlanNodeBuilder(logicalPlan)(idGenerators, dataTypeConverter, dataConverter, postProcessor) {
 
-  override def resolveAttributeChild(attribute: Attribute): Option[Expression] = {
-    operation.projectList
-      .find(_.exprId == attribute.exprId)
-      .map(_.asInstanceOf[Alias])
-  }
+  override def resolveAttributeChild(attribute: Attribute): Option[Expression] =
+    Some(logicalPlan.generator)
 }

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/GenericPlanNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/GenericPlanNodeBuilder.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package za.co.absa.spline.harvester.builder
+package za.co.absa.spline.harvester.builder.plan
 
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import za.co.absa.commons.lang.OptionImplicits._
@@ -23,7 +23,7 @@ import za.co.absa.spline.harvester.converter.{DataConverter, DataTypeConverter, 
 import za.co.absa.spline.harvester.postprocessing.PostProcessor
 import za.co.absa.spline.producer.model.DataOperation
 
-class GenericNodeBuilder
+class GenericPlanNodeBuilder
   (val logicalPlan: LogicalPlan)
   (val idGenerators: IdGeneratorsBundle, val dataTypeConverter: DataTypeConverter, val dataConverter: DataConverter, postProcessor: PostProcessor)
   extends PlanOperationNodeBuilder {

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/JoinNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/JoinNodeBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 ABSA Group Limited
+ * Copyright 2021 ABSA Group Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,22 +14,28 @@
  * limitations under the License.
  */
 
-package za.co.absa.spline.harvester.builder
+package za.co.absa.spline.harvester.builder.plan
 
-import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, Expression}
-import org.apache.spark.sql.catalyst.plans.logical.Aggregate
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.plans.logical.Join
 import za.co.absa.spline.harvester.IdGeneratorsBundle
 import za.co.absa.spline.harvester.converter.{DataConverter, DataTypeConverter}
 import za.co.absa.spline.harvester.postprocessing.PostProcessor
+import za.co.absa.spline.producer.model.DataOperation
 
-class AggregateNodeBuilder
-  (operation: Aggregate)
+class JoinNodeBuilder
+  (operation: Join)
   (idGenerators: IdGeneratorsBundle, dataTypeConverter: DataTypeConverter, dataConverter: DataConverter, postProcessor: PostProcessor)
-  extends GenericNodeBuilder(operation)(idGenerators, dataTypeConverter, dataConverter, postProcessor) {
+  extends GenericPlanNodeBuilder(operation)(idGenerators, dataTypeConverter, dataConverter, postProcessor) with Logging {
 
-  override def resolveAttributeChild(attribute: Attribute): Option[Expression] = {
-    operation.aggregateExpressions
-      .find(_.exprId == attribute.exprId)
-      .map(_.asInstanceOf[Alias])
+  override def build(): DataOperation = {
+
+    val duplicates = operation.output.groupBy(_.exprId).collect { case (exprId, attrs) if attrs.length > 1 => exprId }
+    if (duplicates.nonEmpty) {
+      logWarning(s"Duplicated attributes found in Join operation output, ExprIds of duplicates: $duplicates")
+    }
+
+    super.build()
   }
+
 }

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/PlanOperationNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/PlanOperationNodeBuilder.scala
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-package za.co.absa.spline.harvester.builder
+package za.co.absa.spline.harvester.builder.plan
 
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.{expressions => sparkExprssions}
 import za.co.absa.commons.lang.CachingConverter
 import za.co.absa.spline.harvester.IdGeneratorsBundle
+import za.co.absa.spline.harvester.builder.OperationNodeBuilder
 import za.co.absa.spline.harvester.converter._
 import za.co.absa.spline.producer.model.{Attribute, FunctionalExpression, Literal}
 

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/UnionNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/UnionNodeBuilder.scala
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-package za.co.absa.spline.harvester.builder
+package za.co.absa.spline.harvester.builder.plan
 
 import org.apache.spark.sql.catalyst.plans.logical.Union
 import org.apache.spark.sql.catalyst.{expressions => sparkExprssions}
 import za.co.absa.commons.lang.OptionImplicits._
 import za.co.absa.spline.harvester.IdGeneratorsBundle
-import za.co.absa.spline.harvester.builder.UnionNodeBuilder._
+import za.co.absa.spline.harvester.builder.plan.UnionNodeBuilder.{ExtraFields, Names}
 import za.co.absa.spline.harvester.converter.{DataConverter, DataTypeConverter}
 import za.co.absa.spline.harvester.postprocessing.PostProcessor
 import za.co.absa.spline.producer.model.{AttrOrExprRef, Attribute, FunctionalExpression}
@@ -28,7 +28,7 @@ import za.co.absa.spline.producer.model.{AttrOrExprRef, Attribute, FunctionalExp
 class UnionNodeBuilder
 (override val logicalPlan: Union)
   (idGenerators: IdGeneratorsBundle, dataTypeConverter: DataTypeConverter, dataConverter: DataConverter, postProcessor: PostProcessor)
-  extends GenericNodeBuilder(logicalPlan)(idGenerators, dataTypeConverter, dataConverter, postProcessor) {
+  extends GenericPlanNodeBuilder(logicalPlan)(idGenerators, dataTypeConverter, dataConverter, postProcessor) {
 
   private lazy val unionInputs: Seq[Seq[Attribute]] = inputAttributes.transpose
 

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/WindowNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/WindowNodeBuilder.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package za.co.absa.spline.harvester.builder
+package za.co.absa.spline.harvester.builder.plan
 
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, NamedExpression}
 import org.apache.spark.sql.catalyst.plans.logical.Window
@@ -26,7 +26,7 @@ import za.co.absa.spline.harvester.postprocessing.PostProcessor
 class WindowNodeBuilder
   (operation: Window)
   (idGenerators: IdGeneratorsBundle, dataTypeConverter: DataTypeConverter, dataConverter: DataConverter, postProcessor: PostProcessor)
-  extends GenericNodeBuilder(operation)(idGenerators, dataTypeConverter, dataConverter, postProcessor) {
+  extends GenericPlanNodeBuilder(operation)(idGenerators, dataTypeConverter, dataConverter, postProcessor) {
 
   override def resolveAttributeChild(attribute: Attribute): Option[Expression] = {
     WindowNodeBuilder.extractExpressions(operation)

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/read/ReadNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/read/ReadNodeBuilder.scala
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-package za.co.absa.spline.harvester.builder.read
+package za.co.absa.spline.harvester.builder.plan.read
 
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import za.co.absa.commons.lang.OptionImplicits._
 import za.co.absa.spline.harvester.IdGeneratorsBundle
 import za.co.absa.spline.harvester.ModelConstants.OperationExtras
-import za.co.absa.spline.harvester.builder.PlanOperationNodeBuilder
+import za.co.absa.spline.harvester.builder.plan.PlanOperationNodeBuilder
+import za.co.absa.spline.harvester.builder.read.ReadCommand
 import za.co.absa.spline.harvester.converter.{DataConverter, DataTypeConverter, IOParamsConverter}
 import za.co.absa.spline.harvester.postprocessing.PostProcessor
 import za.co.absa.spline.producer.model.ReadOperation

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/write/WriteNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/write/WriteNodeBuilder.scala
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
-package za.co.absa.spline.harvester.builder.write
+package za.co.absa.spline.harvester.builder.plan.write
 
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import za.co.absa.commons.lang.OptionImplicits._
 import za.co.absa.spline.harvester.IdGeneratorsBundle
 import za.co.absa.spline.harvester.ModelConstants.OperationExtras
-import za.co.absa.spline.harvester.builder.PlanOperationNodeBuilder
+import za.co.absa.spline.harvester.builder.plan.PlanOperationNodeBuilder
+import za.co.absa.spline.harvester.builder.write.WriteCommand
 import za.co.absa.spline.harvester.converter.{DataConverter, DataTypeConverter, IOParamsConverter}
 import za.co.absa.spline.harvester.postprocessing.PostProcessor
 import za.co.absa.spline.producer.model.{Attribute, WriteOperation}

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/rdd/GenericRddNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/rdd/GenericRddNodeBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 ABSA Group Limited
+ * Copyright 2022 ABSA Group Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,35 +14,32 @@
  * limitations under the License.
  */
 
-package za.co.absa.spline.harvester.builder
+package za.co.absa.spline.harvester.builder.rdd
 
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.rdd.RDD
 import za.co.absa.commons.lang.OptionImplicits._
 import za.co.absa.spline.harvester.IdGeneratorsBundle
-import za.co.absa.spline.harvester.converter.{DataConverter, DataTypeConverter, OperationParamsConverter}
 import za.co.absa.spline.harvester.postprocessing.PostProcessor
 import za.co.absa.spline.producer.model.DataOperation
 
-class GenericNodeBuilder
-  (val logicalPlan: LogicalPlan)
-  (val idGenerators: IdGeneratorsBundle, val dataTypeConverter: DataTypeConverter, val dataConverter: DataConverter, postProcessor: PostProcessor)
-  extends PlanOperationNodeBuilder {
+class GenericRddNodeBuilder
+  (val rdd: RDD[_])
+  (val idGenerators: IdGeneratorsBundle, postProcessor: PostProcessor)
+  extends RddOperationNodeBuilder {
 
   override protected type R = DataOperation
-
-  protected lazy val operationParamsConverter =
-    new OperationParamsConverter(dataConverter, exprToRefConverter)
 
   override def build(): DataOperation = {
     val dop = DataOperation(
       id = operationId,
-      name = logicalPlan.nodeName.asOption,
+      name = operationNameOption,
       childIds = childIds.asOption,
       output = outputAttributes.map(_.id).asOption,
-      params = operationParamsConverter.convert(logicalPlan).asOption,
+      params = None,
       extra = None
     )
 
     postProcessor.process(dop)
   }
+
 }

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/rdd/RddOperationNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/rdd/RddOperationNodeBuilder.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.spline.harvester.builder.rdd
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.expressions.ExprId
+import za.co.absa.commons.lang.OptionImplicits.NonOptionWrapper
+import za.co.absa.spline.harvester.IdGeneratorsBundle
+import za.co.absa.spline.harvester.builder.OperationNodeBuilder
+import za.co.absa.spline.producer.model.{Attribute, FunctionalExpression, Literal}
+
+trait RddOperationNodeBuilder extends OperationNodeBuilder {
+
+  def rdd: RDD[_]
+
+  protected def idGenerators: IdGeneratorsBundle
+
+  lazy val outputAttributes: Seq[Attribute] = Seq.empty
+
+  override def outputExprToAttMap: Map[ExprId, Attribute] = Map.empty
+
+  lazy val functionalExpressions: Seq[FunctionalExpression] = Seq.empty
+
+  lazy val literals: Seq[Literal] = Seq.empty
+
+  protected def operationNameOption: Option[String] = {
+    rdd.name.asOption.orElse(rdd.getClass.getSimpleName.asOption)
+  }
+}

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/rdd/read/RddReadNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/rdd/read/RddReadNodeBuilder.scala
@@ -32,15 +32,13 @@ class RddReadNodeBuilder
 
   override protected type R = ReadOperation
 
-  //protected lazy val ioParamsConverter = new IOParamsConverter(exprToRefConverter)
-
   override def build(): ReadOperation = {
     val rop = ReadOperation(
       inputSources = command.sourceIdentifier.uris,
       id = operationId,
       name = operationNameOption,
-      output = None, // TODO maybe? outputAttributes.map(_.id).asOption,
-      params = None, //ioParamsConverter.convert(command.params).asOption,
+      output = None,
+      params = None,
       extra = Map(
         OperationExtras.SourceType -> command.sourceIdentifier.format
       ).asOption)

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/rdd/read/RddReadNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/rdd/read/RddReadNodeBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 ABSA Group Limited
+ * Copyright 2022 ABSA Group Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,37 +14,38 @@
  * limitations under the License.
  */
 
-package za.co.absa.spline.harvester.builder.read
+package za.co.absa.spline.harvester.builder.rdd.read
 
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.rdd.RDD
 import za.co.absa.commons.lang.OptionImplicits._
 import za.co.absa.spline.harvester.IdGeneratorsBundle
 import za.co.absa.spline.harvester.ModelConstants.OperationExtras
-import za.co.absa.spline.harvester.builder.PlanOperationNodeBuilder
-import za.co.absa.spline.harvester.converter.{DataConverter, DataTypeConverter, IOParamsConverter}
+import za.co.absa.spline.harvester.builder.rdd.RddOperationNodeBuilder
+import za.co.absa.spline.harvester.builder.read.ReadCommand
 import za.co.absa.spline.harvester.postprocessing.PostProcessor
 import za.co.absa.spline.producer.model.ReadOperation
 
-class ReadNodeBuilder
-  (val command: ReadCommand, val logicalPlan: LogicalPlan )
-  (val idGenerators: IdGeneratorsBundle, val dataTypeConverter: DataTypeConverter, val dataConverter: DataConverter, postProcessor: PostProcessor)
-  extends PlanOperationNodeBuilder {
+class RddReadNodeBuilder
+  (val command: ReadCommand, val rdd: RDD[_])
+  (val idGenerators: IdGeneratorsBundle, postProcessor: PostProcessor)
+  extends RddOperationNodeBuilder {
 
   override protected type R = ReadOperation
 
-  protected lazy val ioParamsConverter = new IOParamsConverter(exprToRefConverter)
+  //protected lazy val ioParamsConverter = new IOParamsConverter(exprToRefConverter)
 
   override def build(): ReadOperation = {
     val rop = ReadOperation(
       inputSources = command.sourceIdentifier.uris,
       id = operationId,
-      name = logicalPlan.nodeName.asOption,
-      output = outputAttributes.map(_.id).asOption,
-      params = ioParamsConverter.convert(command.params).asOption,
+      name = operationNameOption,
+      output = None, // TODO maybe? outputAttributes.map(_.id).asOption,
+      params = None, //ioParamsConverter.convert(command.params).asOption,
       extra = Map(
         OperationExtras.SourceType -> command.sourceIdentifier.format
       ).asOption)
 
     postProcessor.process(rop)
   }
+
 }

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/read/ReadCommand.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/read/ReadCommand.scala
@@ -16,7 +16,6 @@
 
 package za.co.absa.spline.harvester.builder.read
 
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import za.co.absa.spline.harvester.builder.SourceIdentifier
 
-case class ReadCommand(sourceIdentifier: SourceIdentifier, operation: LogicalPlan, params: Map[String, Any])
+case class ReadCommand(sourceIdentifier: SourceIdentifier, params: Map[String, Any])

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/read/ReadCommandExtractor.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/read/ReadCommandExtractor.scala
@@ -16,8 +16,8 @@
 
 package za.co.absa.spline.harvester.builder.read
 
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import za.co.absa.spline.harvester.LineageHarvester.PlanOrRdd
 
 trait ReadCommandExtractor {
-  def asReadCommand(operation: LogicalPlan): Option[ReadCommand]
+  def asReadCommand(planOrRdd: PlanOrRdd): Option[ReadCommand]
 }

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/write/PluggableWriteCommandExtractor.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/write/PluggableWriteCommandExtractor.scala
@@ -39,16 +39,16 @@ class PluggableWriteCommandExtractor(
       .reduce(_ orElse _)
       .lift
 
-  def asWriteCommand(operation: LogicalPlan): Option[WriteCommand] = {
-    val maybeCapturedResult = processFn(operation)
+  def asWriteCommand(logicalPlan: LogicalPlan): Option[WriteCommand] = {
+    val maybeCapturedResult = processFn(logicalPlan)
 
-    if (maybeCapturedResult.isEmpty) warnIfUnimplementedCommand(operation)
+    if (maybeCapturedResult.isEmpty) warnIfUnimplementedCommand(logicalPlan)
 
     maybeCapturedResult.map({
       case (SourceIdentifier(maybeFormat, uris @ _*), mode, plan, params) =>
         val maybeResolvedFormat = maybeFormat.map(dataSourceFormatResolver.resolve)
         val sourceId = SourceIdentifier(maybeResolvedFormat, uris: _*)
-        WriteCommand(operation.nodeName, sourceId, mode, plan, params)
+        WriteCommand(logicalPlan.nodeName, sourceId, mode, plan, params)
     })
   }
 

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/write/WriteCommandExtractor.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/write/WriteCommandExtractor.scala
@@ -19,5 +19,5 @@ package za.co.absa.spline.harvester.builder.write
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 
 trait WriteCommandExtractor {
-  def asWriteCommand(operation: LogicalPlan): Option[WriteCommand]
+  def asWriteCommand(logicalPlan: LogicalPlan): Option[WriteCommand]
 }

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/write/WriteNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/write/WriteNodeBuilder.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import za.co.absa.commons.lang.OptionImplicits._
 import za.co.absa.spline.harvester.IdGeneratorsBundle
 import za.co.absa.spline.harvester.ModelConstants.OperationExtras
-import za.co.absa.spline.harvester.builder.OperationNodeBuilder
+import za.co.absa.spline.harvester.builder.PlanOperationNodeBuilder
 import za.co.absa.spline.harvester.converter.{DataConverter, DataTypeConverter, IOParamsConverter}
 import za.co.absa.spline.harvester.postprocessing.PostProcessor
 import za.co.absa.spline.producer.model.{Attribute, WriteOperation}
@@ -29,10 +29,10 @@ import za.co.absa.spline.producer.model.{Attribute, WriteOperation}
 class WriteNodeBuilder
 (command: WriteCommand)
   (val idGenerators: IdGeneratorsBundle, val dataTypeConverter: DataTypeConverter, val dataConverter: DataConverter, postProcessor: PostProcessor)
-  extends OperationNodeBuilder {
+  extends PlanOperationNodeBuilder {
 
   override protected type R = WriteOperation
-  override val operation: LogicalPlan = command.query
+  override val logicalPlan: LogicalPlan = command.query
 
   protected lazy val ioParamsConverter = new IOParamsConverter(exprToRefConverter)
 

--- a/core/src/main/scala/za/co/absa/spline/harvester/plugin/embedded/JDBCPlugin.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/plugin/embedded/JDBCPlugin.scala
@@ -16,31 +16,45 @@
 
 package za.co.absa.spline.harvester.plugin.embedded
 
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+
 import javax.annotation.Priority
 import org.apache.spark.sql.execution.datasources.jdbc.{JDBCOptions, JdbcRelationProvider}
 import org.apache.spark.sql.execution.datasources.{LogicalRelation, SaveIntoDataSourceCommand}
 import org.apache.spark.sql.sources.BaseRelation
-import za.co.absa.commons.reflect.ReflectionUtils.extractFieldValue
+import za.co.absa.commons.reflect.ReflectionUtils.{extractFieldValue, extractValue}
 import za.co.absa.commons.reflect.extractors.{AccessorMethodValueExtractor, SafeTypeMatchingExtractor}
 import za.co.absa.spline.harvester.builder.SourceIdentifier
-import za.co.absa.spline.harvester.plugin.Plugin.{Precedence, ReadNodeInfo, WriteNodeInfo}
+import za.co.absa.spline.harvester.plugin.Plugin.{Params, Precedence, ReadNodeInfo, WriteNodeInfo}
 import za.co.absa.spline.harvester.plugin.embedded.JDBCPlugin._
-import za.co.absa.spline.harvester.plugin.{BaseRelationProcessing, Plugin, RelationProviderProcessing}
+import za.co.absa.spline.harvester.plugin.{BaseRelationProcessing, Plugin, RddReadNodeProcessing, RelationProviderProcessing}
 
 
 @Priority(Precedence.Normal)
 class JDBCPlugin
   extends Plugin
     with BaseRelationProcessing
-    with RelationProviderProcessing {
+    with RelationProviderProcessing
+    with RddReadNodeProcessing{
 
   override def baseRelationProcessor: PartialFunction[(BaseRelation, LogicalRelation), ReadNodeInfo] = {
     case (`_: JDBCRelation`(jr), _) =>
-      val jdbcOptions = extractFieldValue[JDBCOptions](jr, "jdbcOptions")
-      val url = extractFieldValue[String](jdbcOptions, "url")
-      val params = extractFieldValue[Map[String, String]](jdbcOptions, "parameters")
-      val TableOrQueryFromJDBCOptionsExtractor(toq) = jdbcOptions
-      (asSourceId(url, toq), params)
+      val jdbcOptions = extractValue[JDBCOptions](jr, "jdbcOptions")
+      jdbcOptionsToReadNodeInfo(jdbcOptions)
+  }
+
+  override def rddReadNodeProcessor: PartialFunction[RDD[_], ReadNodeInfo] = {
+    case `_: JDBCRDD`(jdbcRdd) =>
+      val jdbcOptions = extractValue[JDBCOptions](jdbcRdd, "options")
+      jdbcOptionsToReadNodeInfo(jdbcOptions)
+  }
+
+  private def jdbcOptionsToReadNodeInfo(jdbcOptions: JDBCOptions): ReadNodeInfo = {
+    val url = extractValue[String](jdbcOptions, "url")
+    val params = extractValue[Map[String, String]](jdbcOptions, "parameters")
+    val TableOrQueryFromJDBCOptionsExtractor(toq) = jdbcOptions
+    (asSourceId(url, toq), params)
   }
 
   override def relationProviderProcessor: PartialFunction[(AnyRef, SaveIntoDataSourceCommand), WriteNodeInfo] = {
@@ -54,11 +68,9 @@ class JDBCPlugin
 object JDBCPlugin {
 
   object `_: JDBCRelation` extends SafeTypeMatchingExtractor[AnyRef]("org.apache.spark.sql.execution.datasources.jdbc.JDBCRelation")
+  object `_: JDBCRDD` extends SafeTypeMatchingExtractor[RDD[InternalRow]]("org.apache.spark.sql.execution.datasources.jdbc.JDBCRDD")
 
   object TableOrQueryFromJDBCOptionsExtractor extends AccessorMethodValueExtractor[String]("table", "tableOrQuery")
 
   private def asSourceId(connectionUrl: String, table: String) = SourceIdentifier(Some("jdbc"), s"$connectionUrl:$table")
 }
-
-
-

--- a/core/src/main/scala/za/co/absa/spline/harvester/plugin/embedded/RDDPlugin.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/plugin/embedded/RDDPlugin.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.spline.harvester.plugin.embedded
+
+import org.apache.spark.Partition
+import org.apache.spark.rdd.{HadoopRDD, RDD}
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.execution.datasources.FileScanRDD
+import za.co.absa.commons.reflect.ReflectionUtils
+import za.co.absa.spline.harvester.builder._
+import za.co.absa.spline.harvester.plugin.Plugin.{Params, Precedence}
+import za.co.absa.spline.harvester.plugin.{Plugin, RddReadNodeProcessing}
+import za.co.absa.spline.harvester.qualifier.PathQualifier
+
+import java.net.URI
+import javax.annotation.Priority
+import scala.language.reflectiveCalls
+
+@Priority(Precedence.Normal)
+class RDDPlugin(
+  pathQualifier: PathQualifier,
+  session: SparkSession)
+  extends Plugin
+    with RddReadNodeProcessing  {
+
+  override def rddReadNodeProcessor: PartialFunction[RDD[_], (SourceIdentifier, Params)] = {
+    case fsr: FileScanRDD =>
+      val uris = fsr.filePartitions.flatMap(_.files.map(_.filePath))
+      (SourceIdentifier(None, uris: _*), Map.empty)
+    case hr: HadoopRDD[_, _]  =>
+      val partitions = ReflectionUtils.extractValue[Array[Partition]](hr, "partitions_")
+      val uris = partitions.map(hadoopPartitionToUriString)
+      (SourceIdentifier(None, uris: _*), Map.empty)
+  }
+
+  private def hadoopPartitionToUriString(hadoopPartition: Partition): String = {
+    val inputSplit = ReflectionUtils.extractValue[AnyRef](hadoopPartition, "inputSplit")
+    val fileSplitT = ReflectionUtils.extractValue[AnyRef](inputSplit, "t")
+    val fileSplitFs = ReflectionUtils.extractValue[AnyRef](fileSplitT, "fs")
+    val file = ReflectionUtils.extractValue[AnyRef](fileSplitFs, "file")
+    val uri = ReflectionUtils.extractValue[URI](file, "uri")
+
+    uri.toString
+  }
+
+}

--- a/core/src/main/scala/za/co/absa/spline/harvester/plugin/pluginModel.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/plugin/pluginModel.scala
@@ -16,6 +16,7 @@
 
 package za.co.absa.spline.harvester.plugin
 
+import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.datasources.{LogicalRelation, SaveIntoDataSourceCommand}
 import org.apache.spark.sql.sources.{BaseRelation, CreatableRelationProvider}
@@ -40,6 +41,15 @@ trait DataSourceFormatNameResolving {
 trait ReadNodeProcessing {
   self: Plugin =>
   def readNodeProcessor: PartialFunction[LogicalPlan, ReadNodeInfo]
+}
+
+/**
+ * Matches on RDDs [[org.apache.spark.rdd.RDD]]
+ * capturing ones that represent `read`-operations.
+ */
+trait RddReadNodeProcessing {
+  self: Plugin =>
+  def rddReadNodeProcessor: PartialFunction[RDD[_], ReadNodeInfo]
 }
 
 /**

--- a/core/src/main/scala/za/co/absa/spline/harvester/postprocessing/AttributeReorderingFilter.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/postprocessing/AttributeReorderingFilter.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import za.co.absa.commons.reflect.ReflectionUtils._
 import za.co.absa.commons.reflect.extractors.SafeTypeMatchingExtractor
 import za.co.absa.spline.harvester.HarvestingContext
-import za.co.absa.spline.harvester.builder.UnionNodeBuilder.ExtraFields
+import za.co.absa.spline.harvester.builder.plan.UnionNodeBuilder.ExtraFields
 import za.co.absa.spline.harvester.plugin.embedded.DataSourceV2Plugin.{IsByName, `_: V2WriteCommand`}
 import za.co.absa.spline.producer.model.{DataOperation, ExecutionPlan, WriteOperation}
 

--- a/core/src/main/scala/za/co/absa/spline/producer/model/DataOperation.scala
+++ b/core/src/main/scala/za/co/absa/spline/producer/model/DataOperation.scala
@@ -23,4 +23,4 @@ case class DataOperation (
   output: Option[Seq[String]],
   params: Option[Map[String, Any]],
   extra: Option[Map[String, Any]]
-)
+) extends Operation

--- a/core/src/main/scala/za/co/absa/spline/producer/model/Operation.scala
+++ b/core/src/main/scala/za/co/absa/spline/producer/model/Operation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 ABSA Group Limited
+ * Copyright 2022 ABSA Group Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,4 @@
 
 package za.co.absa.spline.producer.model
 
-case class WriteOperation (
-  outputSource: String,
-  append: Boolean,
-  id: String,
-  name: Option[String],
-  childIds: Seq[String],
-  params: Option[Map[String, Any]],
-  extra: Option[Map[String, Any]]
-) extends Operation
+trait Operation

--- a/core/src/main/scala/za/co/absa/spline/producer/model/ReadOperation.scala
+++ b/core/src/main/scala/za/co/absa/spline/producer/model/ReadOperation.scala
@@ -23,4 +23,4 @@ case class ReadOperation (
   output: Option[Seq[String]],
   params: Option[Map[String, Any]],
   extra: Option[Map[String, Any]]
-)
+) extends Operation

--- a/core/src/test/scala/za/co/absa/spline/harvester/builder/BuilderSpec.scala
+++ b/core/src/test/scala/za/co/absa/spline/harvester/builder/BuilderSpec.scala
@@ -23,7 +23,8 @@ import org.mockito.Mockito.when
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
-import za.co.absa.spline.harvester.builder.read.{ReadCommand, ReadNodeBuilder}
+import za.co.absa.spline.harvester.builder.plan.read.ReadNodeBuilder
+import za.co.absa.spline.harvester.builder.read.ReadCommand
 import za.co.absa.spline.harvester.converter.{DataConverter, DataTypeConverter}
 import za.co.absa.spline.harvester.postprocessing.PostProcessor
 import za.co.absa.spline.harvester.{IdGeneratorsBundle, SequentialIdGenerator}

--- a/core/src/test/scala/za/co/absa/spline/harvester/builder/BuilderSpec.scala
+++ b/core/src/test/scala/za/co/absa/spline/harvester/builder/BuilderSpec.scala
@@ -23,10 +23,10 @@ import org.mockito.Mockito.when
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
-import za.co.absa.spline.harvester.{IdGenerator, IdGeneratorsBundle, SequentialIdGenerator}
 import za.co.absa.spline.harvester.builder.read.{ReadCommand, ReadNodeBuilder}
 import za.co.absa.spline.harvester.converter.{DataConverter, DataTypeConverter}
 import za.co.absa.spline.harvester.postprocessing.PostProcessor
+import za.co.absa.spline.harvester.{IdGeneratorsBundle, SequentialIdGenerator}
 import za.co.absa.spline.producer.model.ReadOperation
 
 class BuilderSpec extends AnyFlatSpec with Matchers with MockitoSugar {
@@ -46,12 +46,11 @@ class BuilderSpec extends AnyFlatSpec with Matchers with MockitoSugar {
 
     val command = ReadCommand(
       SourceIdentifier(Some("CSV"), "whaateverpath"),
-      logicalPlanStub,
       Map("caseSensitiveKey" -> "blabla")
     )
 
     val readNode =
-      new ReadNodeBuilder(command)(idGeneratorsMock, dataTypeConverterMock, dataConverterMock, postProcessorMock)
+      new ReadNodeBuilder(command, logicalPlanStub)(idGeneratorsMock, dataTypeConverterMock, dataConverterMock, postProcessorMock)
         .build()
 
     readNode.params.get.keySet should contain("caseSensitiveKey")

--- a/examples/src/main/scala/za/co/absa/spline/example/batch/ExampleRDDJob.scala
+++ b/examples/src/main/scala/za/co/absa/spline/example/batch/ExampleRDDJob.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.spline.example.batch
+
+import org.apache.spark.sql.functions.col
+import za.co.absa.spline.SparkApp
+
+object ExampleRDDJob extends SparkApp("Example 1 (successful)") {
+
+  import org.apache.spark.sql._
+  import za.co.absa.spline.harvester.SparkLineageInitializer._
+
+  // Initializing library to hook up to Apache Spark
+  spark.enableLineageTracking()
+
+  // A business logic of a spark job ...
+
+  val rddData = spark.read
+    .option("header", "true")
+    .option("inferSchema", "true")
+    .parquet("data/output/batch/union_job_results")
+    .select(col("_1").cast("int"))
+    .rdd
+
+  val rddRes = rddData.map(row => row.getInt(0) * 2)
+
+  rddRes
+    .toDF("foo")
+    .write
+    .mode(SaveMode.Append)
+    .parquet("data/output/batch/jobrdd_results")
+}

--- a/integration-tests/data/cities.csv
+++ b/integration-tests/data/cities.csv
@@ -1,0 +1,4 @@
+name,population
+Prague,1275406
+ape Town,4710000
+Johannesburg,5635127

--- a/integration-tests/data/cities.csv
+++ b/integration-tests/data/cities.csv
@@ -1,4 +1,4 @@
 name,population
 Prague,1275406
-ape Town,4710000
+Cape Town,4710000
 Johannesburg,5635127

--- a/integration-tests/data/cities.jsonl
+++ b/integration-tests/data/cities.jsonl
@@ -1,0 +1,3 @@
+{"name": "Prague", "population": 1275406}
+{"name": "Cape Town", "population": 4710000}
+{"name": "Johannesburg", "population": 5635127}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -272,6 +272,7 @@
                 <artifactId>apache-rat-plugin</artifactId>
                 <configuration>
                     <excludes combine.children="append">
+                        <exclude>data/**</exclude>
                         <exclude>spark-warehouse/**</exclude>
                         <exclude>metastore_db/**</exclude>
                     </excludes>

--- a/integration-tests/src/main/scala/za/co/absa/spline/test/fixture/JDBCFixture.scala
+++ b/integration-tests/src/main/scala/za/co/absa/spline/test/fixture/JDBCFixture.scala
@@ -20,6 +20,9 @@ package za.co.absa.spline.test.fixture
 import org.scalatest.Suite
 import za.co.absa.commons.io.TempFile
 
+/**
+ * Using SQLite (whole database is stored in a single file without need for a db server)
+ */
 trait JDBCFixture {
   this: Suite =>
 

--- a/integration-tests/src/test/scala/za/co/absa/spline/RddSpec.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/RddSpec.scala
@@ -83,7 +83,7 @@ class RddSpec extends AsyncFlatSpec
             val rddData = spark.read
               .option("header", "true")
               .option("inferSchema", "true")
-              .json("integration-tests/data/cities.jsonl")
+              .json("data/cities.jsonl")
               .rdd
 
             val schema = StructType(Array(StructField("n", StringType), StructField("p", LongType)))
@@ -94,7 +94,7 @@ class RddSpec extends AsyncFlatSpec
           }
         } yield {
           plan2.operations.reads.get(0).inputSources(0) should startWith("file:/")
-          plan2.operations.reads.get(0).inputSources(0) should endWith("integration-tests/data/cities.jsonl")
+          plan2.operations.reads.get(0).inputSources(0) should endWith("data/cities.jsonl")
         }
       }
     }
@@ -109,7 +109,7 @@ class RddSpec extends AsyncFlatSpec
             val rddData = spark.read
               .option("header", "true")
               .schema(schema)
-              .csv("integration-tests/data/cities.csv")
+              .csv("data/cities.csv")
               .rdd
 
             spark.createDataFrame(rddData, schema)
@@ -119,7 +119,7 @@ class RddSpec extends AsyncFlatSpec
           }
         } yield {
           plan2.operations.reads.get(0).inputSources(0) should startWith("file:/")
-          plan2.operations.reads.get(0).inputSources(0) should endWith("integration-tests/data/cities.csv")
+          plan2.operations.reads.get(0).inputSources(0) should endWith("data/cities.csv")
         }
       }
     }
@@ -132,7 +132,7 @@ class RddSpec extends AsyncFlatSpec
         for {
           (plan2, Seq(event2)) <- lineageCaptor.lineageOf {
             val rddData = spark
-              .sparkContext.textFile("integration-tests/data/cities.csv")
+              .sparkContext.textFile("data/cities.csv")
               .map(line => Row.fromSeq(line.split(",").take(2)))
 
             val schema = StructType(Array(StructField("n", StringType), StructField("p", StringType)))
@@ -143,7 +143,7 @@ class RddSpec extends AsyncFlatSpec
           }
         } yield {
           plan2.operations.reads.get(0).inputSources(0) should startWith("file:/")
-          plan2.operations.reads.get(0).inputSources(0) should endWith("integration-tests/data/cities.csv")
+          plan2.operations.reads.get(0).inputSources(0) should endWith("data/cities.csv")
         }
       }
     }

--- a/integration-tests/src/test/scala/za/co/absa/spline/RddSpec.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/RddSpec.scala
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package za.co.absa.spline
+
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.{DataFrame, Row, SaveMode}
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+import za.co.absa.commons.io.TempDirectory
+import za.co.absa.spline.test.LineageWalker
+import za.co.absa.spline.test.fixture.spline.SplineFixture
+import za.co.absa.spline.test.fixture.{JDBCFixture, SparkDatabaseFixture, SparkFixture}
+
+import java.util.Properties
+
+class RddSpec extends AsyncFlatSpec
+  with Matchers
+  with SparkFixture
+  with SplineFixture
+  with SparkDatabaseFixture
+  with JDBCFixture {
+
+  private val inputPath = TempDirectory().deleteOnExit().path
+  private val tempPath = TempDirectory().deleteOnExit().path
+
+  it should "support parquet read" in
+    withNewSparkSession { implicit spark =>
+      withLineageTracking { lineageCaptor =>
+        import spark.implicits._
+
+        val testData = {
+          Seq((1014, "Warsaw"), (1002, "Corte")).toDF("ID", "NAME")
+        }
+
+        for {
+          (plan1, Seq(event1)) <- lineageCaptor.lineageOf {
+            testData.write.format("parquet").mode("overwrite").save(inputPath.toString)
+          }
+          (plan2, Seq(event2)) <- lineageCaptor.lineageOf {
+            val rddData = spark.read
+              .option("header", "true")
+              .option("inferSchema", "true")
+              .parquet(inputPath.toString)
+              .select(col("ID").cast("int"))
+              .rdd
+
+            val rddRes = rddData.map(row => row.getInt(0) * 2)
+
+            rddRes
+              .toDF("foo")
+              .write
+              .mode(SaveMode.Overwrite)
+              .parquet(tempPath.toString)
+          }
+        } yield {
+          plan2.operations.reads.get(0).inputSources(0) should startWith(s"file://$inputPath")
+          plan2.operations.write.extra.get("destinationType") shouldBe Some("parquet")
+        }
+      }
+    }
+
+  it should "support json read" in
+    withNewSparkSession { implicit spark =>
+      withLineageTracking { lineageCaptor =>
+        for {
+          (plan2, Seq(event2)) <- lineageCaptor.lineageOf {
+            val rddData = spark.read
+              .option("header", "true")
+              .option("inferSchema", "true")
+              .json("integration-tests/data/cities.jsonl")
+              .rdd
+
+            val schema = StructType(Array(StructField("n", StringType), StructField("p", LongType)))
+            spark.createDataFrame(rddData, schema)
+              .write
+              .mode(SaveMode.Overwrite)
+              .parquet(tempPath.toString)
+          }
+        } yield {
+          plan2.operations.reads.get(0).inputSources(0) should startWith("file:/")
+          plan2.operations.reads.get(0).inputSources(0) should endWith("integration-tests/data/cities.jsonl")
+        }
+      }
+    }
+
+  it should "support csv read" in
+    withNewSparkSession { implicit spark =>
+      withLineageTracking { lineageCaptor =>
+        for {
+          (plan2, Seq(event2)) <- lineageCaptor.lineageOf {
+            val schema = StructType(Array(StructField("name", StringType), StructField("population", LongType)))
+
+            val rddData = spark.read
+              .option("header", "true")
+              .schema(schema)
+              .csv("integration-tests/data/cities.csv")
+              .rdd
+
+            spark.createDataFrame(rddData, schema)
+              .write
+              .mode(SaveMode.Overwrite)
+              .parquet(tempPath.toString)
+          }
+        } yield {
+          plan2.operations.reads.get(0).inputSources(0) should startWith("file:/")
+          plan2.operations.reads.get(0).inputSources(0) should endWith("integration-tests/data/cities.csv")
+        }
+      }
+    }
+
+
+
+  it should "support rdd json read" in
+    withNewSparkSession { implicit spark =>
+      withLineageTracking { lineageCaptor =>
+        for {
+          (plan2, Seq(event2)) <- lineageCaptor.lineageOf {
+            val rddData = spark
+              .sparkContext.textFile("integration-tests/data/cities.csv")
+              .map(line => Row.fromSeq(line.split(",").take(2)))
+
+            val schema = StructType(Array(StructField("n", StringType), StructField("p", StringType)))
+            spark.createDataFrame(rddData, schema)
+              .write
+              .mode(SaveMode.Overwrite)
+              .parquet(tempPath.toString)
+          }
+        } yield {
+          plan2.operations.reads.get(0).inputSources(0) should startWith("file:/")
+          plan2.operations.reads.get(0).inputSources(0) should endWith("integration-tests/data/cities.csv")
+        }
+      }
+    }
+
+  it should "support rdd direct data" in
+    withNewSparkSession { implicit spark =>
+      withLineageTracking { lineageCaptor =>
+        for {
+          (plan2, Seq(event2)) <- lineageCaptor.lineageOf {
+            val rddData = spark
+              .sparkContext.parallelize(Array(1, 2, 3, 4))
+              .map(Row(_))
+
+            val schema = StructType(Array(StructField("n", IntegerType)))
+            spark.createDataFrame(rddData, schema)
+              .write
+              .mode(SaveMode.Overwrite)
+              .parquet(tempPath.toString)
+          }
+        } yield {
+          import za.co.absa.spline.test.ProducerModelImplicits._
+          implicit val lineageWalker = LineageWalker(plan2)
+
+          plan2.operations.reads should be(None)
+
+          val write = plan2.operations.write
+          val (readLeaves, dataLeaves) = write.dagLeaves
+
+          readLeaves.size should be(0)
+          dataLeaves.size should be(1)
+
+          dataLeaves.head.name.get should be("ParallelCollectionRDD")
+        }
+      }
+    }
+
+  it should "support JDBC as a source" in
+    withNewSparkSession { implicit spark =>
+      withLineageTracking { captor =>
+        val tableName = s"someTable${System.currentTimeMillis()}"
+
+        val schema = StructType(StructField("ID", IntegerType, nullable = false) :: StructField("NAME", StringType, nullable = false) :: Nil)
+
+        val testData: DataFrame = {
+          val rdd = spark.sparkContext.parallelize(Row(1014, "Warsaw") :: Row(1002, "Corte") :: Nil)
+          spark.sqlContext.createDataFrame(rdd, schema)
+        }
+        for {
+          (plan1, _) <- captor.lineageOf(
+            testData
+              .write.jdbc(jdbcConnectionString, tableName, new Properties))
+
+          (plan2, _) <- captor.lineageOf {
+            val rddData = spark
+              .read.jdbc(jdbcConnectionString, tableName, new Properties)
+              .rdd
+
+            spark.createDataFrame(rddData, schema)
+              .write
+              .mode(SaveMode.Overwrite)
+              .parquet(tempPath.toString)
+          }
+        } yield {
+          plan2.operations.reads.get.head.inputSources.head shouldBe s"$jdbcConnectionString:$tableName"
+          plan2.operations.reads.get.head.extra.get("sourceType") shouldBe Some("jdbc")
+        }
+      }
+    }
+}

--- a/integration-tests/src/test/scala/za/co/absa/spline/ViewAttributeLineageSpec.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/ViewAttributeLineageSpec.scala
@@ -57,7 +57,7 @@ class ViewAttributeLineageSpec
             } yield {
               implicit val walker: LineageWalker = LineageWalker(plan)
 
-              val writeOutput = plan.operations.write.precedingOp.outputAttributes
+              val writeOutput = plan.operations.write.precedingDataOp.outputAttributes
               val outAttribute = writeOutput(0)
 
               val reads = plan.operations.reads.get
@@ -91,7 +91,7 @@ class ViewAttributeLineageSpec
           } yield {
             implicit val walker: LineageWalker = LineageWalker(plan)
 
-            val writeOutput = plan.operations.write.precedingOp.outputAttributes
+            val writeOutput = plan.operations.write.precedingDataOp.outputAttributes
             val outAttribute = writeOutput(0)
 
             val reads = plan.operations.reads.get
@@ -124,7 +124,7 @@ class ViewAttributeLineageSpec
           } yield {
             implicit val walker: LineageWalker = LineageWalker(plan)
 
-            val writeOutput = plan.operations.write.precedingOp.outputAttributes
+            val writeOutput = plan.operations.write.precedingDataOp.outputAttributes
             val outAttribute = writeOutput(0)
 
             val reads = plan.operations.reads.get

--- a/integration-tests/src/test/scala/za/co/absa/spline/harvester/LineageHarvesterSpec.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/harvester/LineageHarvesterSpec.scala
@@ -213,17 +213,17 @@ class LineageHarvesterSpec extends AsyncFlatSpec
           write.params should contain(Map("path" -> tmpPath))
           write.extra should contain(Map("destinationType" -> Some("parquet")))
 
-          val union = write.precedingOp
+          val union = write.precedingDataOp
           union.name should contain("Union")
           union.childIds.get.size should be(2)
 
-          val Seq(filter1, maybeFilter2) = union.precedingOps
+          val Seq(filter1, maybeFilter2) = union.precedingDataOps
           filter1.name should contain("Filter")
           filter1.params.get should contain key "condition"
 
           val filter2 =
             if (maybeFilter2.name.get == "Project") {
-              maybeFilter2.precedingOp // skip additional select (in Spark 3.0 and 3.1 only)
+              maybeFilter2.precedingDataOp // skip additional select (in Spark 3.0 and 3.1 only)
             } else {
               maybeFilter2
             }
@@ -231,10 +231,10 @@ class LineageHarvesterSpec extends AsyncFlatSpec
           filter2.name should contain("Filter")
           filter2.params.get should contain key "condition"
 
-          val localRelation1 = filter1.precedingOp
+          val localRelation1 = filter1.precedingDataOp
           localRelation1.name should contain("LocalRelation")
 
-          val localRelation2 = filter2.precedingOp
+          val localRelation2 = filter2.precedingDataOp
           localRelation2.name should contain("LocalRelation")
 
           inside(union.outputAttributes) { case Seq(i, d, s) =>
@@ -302,11 +302,11 @@ class LineageHarvesterSpec extends AsyncFlatSpec
           write.params should contain(Map("path" -> tmpPath))
           write.extra should contain(Map("destinationType" -> Some("parquet")))
 
-          val join = write.precedingOp
+          val join = write.precedingDataOp
           join.name should contain("Join")
           join.childIds.get.size should be(2)
 
-          val Seq(filter, aggregate) = join.precedingOps
+          val Seq(filter, aggregate) = join.precedingDataOps
           filter.name should contain("Filter")
           filter.params.get should contain key "condition"
 
@@ -314,13 +314,13 @@ class LineageHarvesterSpec extends AsyncFlatSpec
           aggregate.params.get should contain key "groupingExpressions"
           aggregate.params.get should contain key "aggregateExpressions"
 
-          val project = aggregate.precedingOp
+          val project = aggregate.precedingDataOp
           project.name should contain("Project")
 
-          val localRelation1 = filter.precedingOp
+          val localRelation1 = filter.precedingDataOp
           localRelation1.name should contain("LocalRelation")
 
-          val localRelation2 = project.precedingOp
+          val localRelation2 = project.precedingDataOp
           localRelation2.name should contain("LocalRelation")
 
           inside(join.outputAttributes) { case Seq(i, d, s, a, min, max) =>


### PR DESCRIPTION
This PR adds rdd support for cases when the write itself is not rdd but somewhere in the lineage graph an rdd is used. So it captures operation in the middle and read operation.

- add another builder branch for processing RDDs
- refactor builders for plan and rdd into separated sub-packages
- add another plugin type for RDD reads
- rename variables to keep distinction between Spark's plan and Spline Operation abstraction
- add leaf finding capabilities to LineageWalker
- add test for RDD lineages
