### PR TITLE
Adding security header for spline http dispatcher

### DIFF
--- a/core/src/main/resources/spline.default.properties
+++ b/core/src/main/resources/spline.default.properties
@@ -52,6 +52,7 @@ spline.lineageDispatcher.http.className=za.co.absa.spline.harvester.dispatcher.H
 spline.lineageDispatcher.http.producer.url=
 spline.lineageDispatcher.http.timeout.connection=2000
 spline.lineageDispatcher.http.timeout.read=120000
+spline.lineageDispatcher.http.securityHeader.key=somekeys
 # Spline Producer API version to use.
 # If unspecified, the protocol version is determined from the endpoint handshake response.
 # If unspecified and a custom (non-Spline) endpoint is used, the Producer API version is automatically set to 1 (the oldest one supported).

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/HttpLineageDispatcher.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/HttpLineageDispatcher.scala
@@ -107,7 +107,8 @@ object HttpLineageDispatcher extends Logging {
       Http,
       config.producerUrl,
       config.connTimeout,
-      config.readTimeout
+      config.readTimeout,
+      config.secHeader
     )
   }
 

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/SplineHeaders.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/SplineHeaders.scala
@@ -26,6 +26,7 @@ object SplineHeaders {
   // Http specific
   val AcceptRequestEncoding = s"$Prefix-Accept-Request-Encoding"
   val Timeout = "X-SPLINE-TIMEOUT"
+  val HttpSecurityKey = "X-FUNCTIONS_KEY"
 
   // Kafka specific
   val SplineEntityType = s"$Prefix-Entity-Type"

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/HttpLineageDispatcherConfig.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/HttpLineageDispatcherConfig.scala
@@ -30,6 +30,7 @@ object HttpLineageDispatcherConfig {
   val ReadTimeoutMsKey = "timeout.read"
   val ApiVersion = "apiVersion"
   val RequestCompression = "requestCompression"
+  val securityHeaderKey = "securityHeader.key"
 
   def apply(c: Configuration) = new HttpLineageDispatcherConfig(c)
 }
@@ -38,7 +39,9 @@ class HttpLineageDispatcherConfig(config: Configuration) {
   val producerUrl: String = config.getRequiredString(ProducerUrlProperty)
   val connTimeout: Duration = config.getRequiredLong(ConnectionTimeoutMsKey).millis
   val readTimeout: Duration = config.getRequiredLong(ReadTimeoutMsKey).millis
+  val secHeader: String = config.getRequiredString(securityHeaderKey)
 
+  // def secHeader: Option[String] = config.getOptionalString(securityHeaderKey)
   def apiVersionOption: Option[Version] = config.getOptionalString(ApiVersion).map(stringToVersion)
   def requestCompressionOption: Option[Boolean] = config.getOptionalBoolean(RequestCompression)
 

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/rest/RestClient.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/rest/RestClient.scala
@@ -37,7 +37,8 @@ object RestClient extends Logging {
     baseHttp: BaseHttp,
     baseURL: String,
     connectionTimeout: Duration,
-    readTimeout: Duration): RestClient = {
+    readTimeout: Duration,
+    secHeader: String): RestClient = {
 
     logDebug(s"baseURL = $baseURL")
     logDebug(s"connectionTimeout = $connectionTimeout")
@@ -49,6 +50,7 @@ object RestClient extends Logging {
         baseHttp(s"$baseURL/$resource")
           .timeout(connectionTimeout.toMillis.toInt, readTimeout.toMillis.toInt)
           .header(SplineHeaders.Timeout, readTimeout.toMillis.toString)
+          .header(SplineHeaders.HttpSecurityKey, secHeader)
           .compress(true))
     }
   }


### PR DESCRIPTION
As per discussion in https://github.com/AbsaOSS/spline-spark-agent/discussions/448
A security property can be added in http property in spline.properties