### PR TITLE
issue #566 SparkFixture: merge `withCustomSparkSession()` and `withRe…

### DIFF
--- a/integration-tests/src/test/scala/za/co/absa/spline/AttributeReorderingFilterSpec.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/AttributeReorderingFilterSpec.scala
@@ -34,36 +34,34 @@ class AttributeReorderingFilterSpec extends AsyncFlatSpec
 
   "AttributeOrderEnrichingFilter" should "produce lineage with correct attribute order" taggedAs
     ignoreIf(ver"$SPARK_VERSION" < ver"3.0.0" || ver"$SPARK_VERSION" >= ver"3.3.0") in
-    withRestartingSparkContext {
-      withCustomSparkSession(_
-        .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
-        .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
-      ) { implicit spark =>
-        withLineageTracking { lineageCaptor =>
-          withDatabase("testDB") {
+    withRestartingSparkSession(_
+      .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+      .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+    ) { implicit spark =>
+      withLineageTracking { lineageCaptor =>
+        withDatabase("testDB") {
 
-            import spark.implicits._
+          import spark.implicits._
 
-            for {
-              (plan, _) <- lineageCaptor.lineageOf {
-                spark.sql(s"CREATE TABLE t1 (i int, j int) USING delta")
+          for {
+            (plan, _) <- lineageCaptor.lineageOf {
+              spark.sql(s"CREATE TABLE t1 (i int, j int) USING delta")
 
-                Seq((3, 4)).toDF("j", "i")
-                  .write.format("delta")
-                  .mode("append")
-                  .saveAsTable("t1")
-              }
-            } yield {
-              val write = plan.operations.write
-              val writeChild = getOtherOpById(plan, write.childIds.head)
-
-              getAttributeById(plan, writeChild.output(0)).name should be("i")
-              getAttributeById(plan, writeChild.output(1)).name should be("j")
-
-              val writeChild2 = getOtherOpById(plan, writeChild.childIds.head)
-              val writeChild3 = getOtherOpById(plan, writeChild2.childIds.head)
-              writeChild3.name should be("LocalRelation")
+              Seq((3, 4)).toDF("j", "i")
+                .write.format("delta")
+                .mode("append")
+                .saveAsTable("t1")
             }
+          } yield {
+            val write = plan.operations.write
+            val writeChild = getOtherOpById(plan, write.childIds.head)
+
+            getAttributeById(plan, writeChild.output(0)).name should be("i")
+            getAttributeById(plan, writeChild.output(1)).name should be("j")
+
+            val writeChild2 = getOtherOpById(plan, writeChild.childIds.head)
+            val writeChild3 = getOtherOpById(plan, writeChild2.childIds.head)
+            writeChild3.name should be("LocalRelation")
           }
         }
       }
@@ -72,9 +70,9 @@ class AttributeReorderingFilterSpec extends AsyncFlatSpec
 }
 
 object AttributeReorderingFilterSpec {
-  def getOtherOpById(plan: ExecutionPlan, opId :String): DataOperation =
+  def getOtherOpById(plan: ExecutionPlan, opId: String): DataOperation =
     plan.operations.other.find(_.id == opId).value
 
-  def getAttributeById(plan: ExecutionPlan, attId :String): Attribute =
+  def getAttributeById(plan: ExecutionPlan, attId: String): Attribute =
     plan.attributes.find(_.id == attId).value
 }

--- a/integration-tests/src/test/scala/za/co/absa/spline/AttributeReorderingFilterSpec.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/AttributeReorderingFilterSpec.scala
@@ -34,7 +34,7 @@ class AttributeReorderingFilterSpec extends AsyncFlatSpec
 
   "AttributeOrderEnrichingFilter" should "produce lineage with correct attribute order" taggedAs
     ignoreIf(ver"$SPARK_VERSION" < ver"3.0.0" || ver"$SPARK_VERSION" >= ver"3.3.0") in
-    withRestartingSparkSession(_
+    withIsolatedSparkSession(_
       .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
       .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
     ) { implicit spark =>

--- a/integration-tests/src/test/scala/za/co/absa/spline/DeltaDSV2Spec.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/DeltaDSV2Spec.scala
@@ -38,7 +38,7 @@ class DeltaDSV2Spec extends AsyncFlatSpec
 
   it should "support AppendData V2 command" taggedAs
     ignoreIf(ver"$SPARK_VERSION" < ver"3.0.0") in
-    withCustomSparkSession(_
+    withRestartingSparkSession(_
       .enableHiveSupport
       .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
       .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
@@ -67,7 +67,7 @@ class DeltaDSV2Spec extends AsyncFlatSpec
 
   it should "support OverwriteByExpression V2 command without deleteExpression" taggedAs
     ignoreIf(ver"$SPARK_VERSION" < ver"3.0.0") in
-    withCustomSparkSession(_
+    withRestartingSparkSession(_
       .enableHiveSupport
       .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
       .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
@@ -99,7 +99,7 @@ class DeltaDSV2Spec extends AsyncFlatSpec
 
   it should "support OverwriteByExpression V2 command with deleteExpression" taggedAs
     ignoreIf(ver"$SPARK_VERSION" < ver"3.0.0") in
-    withCustomSparkSession(_
+    withRestartingSparkSession(_
       .enableHiveSupport
       .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
       .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
@@ -138,7 +138,7 @@ class DeltaDSV2Spec extends AsyncFlatSpec
     */
   it should "support OverwritePartitionsDynamic V2 command" taggedAs
     ignoreIf(ver"$SPARK_VERSION" < ver"3.0.0") in
-    withCustomSparkSession(_
+    withRestartingSparkSession(_
       .enableHiveSupport
       .config("hive.exec.dynamic.partition", "true")
       .config("hive.exec.dynamic.partition.mode", "nonstrict")
@@ -173,7 +173,7 @@ class DeltaDSV2Spec extends AsyncFlatSpec
 
   it should "support CreateTableAsSelect V2 command" taggedAs
     ignoreIf(ver"$SPARK_VERSION" < ver"3.0.0") in
-    withCustomSparkSession(_
+    withRestartingSparkSession(_
       .enableHiveSupport
       .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
       .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
@@ -201,7 +201,7 @@ class DeltaDSV2Spec extends AsyncFlatSpec
 
   it should "support ReplaceTableAsSelect V2 command" taggedAs
     ignoreIf(ver"$SPARK_VERSION" < ver"3.0.0") in
-    withCustomSparkSession(_
+    withRestartingSparkSession(_
       .enableHiveSupport
       .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
       .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
@@ -230,7 +230,7 @@ class DeltaDSV2Spec extends AsyncFlatSpec
 
   it should "support DELETE table command" taggedAs
     ignoreIf(ver"$SPARK_VERSION" < ver"3.0.0") in
-    withCustomSparkSession(_
+    withRestartingSparkSession(_
       .enableHiveSupport
       .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
       .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
@@ -263,7 +263,7 @@ class DeltaDSV2Spec extends AsyncFlatSpec
 
   it should "support UPDATE table command" taggedAs
     ignoreIf(ver"$SPARK_VERSION" < ver"3.0.0") in
-    withCustomSparkSession(_
+    withRestartingSparkSession(_
       .enableHiveSupport
       .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
       .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
@@ -297,7 +297,7 @@ class DeltaDSV2Spec extends AsyncFlatSpec
 
   it should "support MERGE INTO table command" taggedAs
     ignoreIf(ver"$SPARK_VERSION" < ver"3.0.0") in
-    withCustomSparkSession(_
+    withRestartingSparkSession(_
       .enableHiveSupport
       .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
       .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")

--- a/integration-tests/src/test/scala/za/co/absa/spline/DeltaDSV2Spec.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/DeltaDSV2Spec.scala
@@ -39,7 +39,7 @@ class DeltaDSV2Spec extends AsyncFlatSpec
 
   it should "support AppendData V2 command" taggedAs
     ignoreIf(ver"$SPARK_VERSION" < ver"3.0.0") in
-    withRestartingSparkSession(_
+    withIsolatedSparkSession(_
       .enableHiveSupport
       .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
       .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
@@ -68,7 +68,7 @@ class DeltaDSV2Spec extends AsyncFlatSpec
 
   it should "support OverwriteByExpression V2 command without deleteExpression" taggedAs
     ignoreIf(ver"$SPARK_VERSION" < ver"3.0.0") in
-    withRestartingSparkSession(_
+    withIsolatedSparkSession(_
       .enableHiveSupport
       .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
       .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
@@ -100,7 +100,7 @@ class DeltaDSV2Spec extends AsyncFlatSpec
 
   it should "support OverwriteByExpression V2 command with deleteExpression" taggedAs
     ignoreIf(ver"$SPARK_VERSION" < ver"3.0.0") in
-    withRestartingSparkSession(_
+    withIsolatedSparkSession(_
       .enableHiveSupport
       .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
       .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
@@ -140,7 +140,7 @@ class DeltaDSV2Spec extends AsyncFlatSpec
     */
   it should "support OverwritePartitionsDynamic V2 command" taggedAs
     ignoreIf(ver"$SPARK_VERSION" < ver"3.0.0") in
-    withRestartingSparkSession(_
+    withIsolatedSparkSession(_
       .enableHiveSupport
       .config("hive.exec.dynamic.partition", "true")
       .config("hive.exec.dynamic.partition.mode", "nonstrict")
@@ -176,7 +176,7 @@ class DeltaDSV2Spec extends AsyncFlatSpec
 
   it should "support CreateTableAsSelect V2 command" taggedAs
     ignoreIf(ver"$SPARK_VERSION" < ver"3.0.0") in
-    withRestartingSparkSession(_
+    withIsolatedSparkSession(_
       .enableHiveSupport
       .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
       .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
@@ -204,7 +204,7 @@ class DeltaDSV2Spec extends AsyncFlatSpec
 
   it should "support ReplaceTableAsSelect V2 command" taggedAs
     ignoreIf(ver"$SPARK_VERSION" < ver"3.0.0") in
-    withRestartingSparkSession(_
+    withIsolatedSparkSession(_
       .enableHiveSupport
       .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
       .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
@@ -233,7 +233,7 @@ class DeltaDSV2Spec extends AsyncFlatSpec
 
   it should "support DELETE table command" taggedAs
     ignoreIf(ver"$SPARK_VERSION" < ver"3.0.0") in
-    withRestartingSparkSession(_
+    withIsolatedSparkSession(_
       .enableHiveSupport
       .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
       .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
@@ -266,7 +266,7 @@ class DeltaDSV2Spec extends AsyncFlatSpec
 
   it should "support UPDATE table command" taggedAs
     ignoreIf(ver"$SPARK_VERSION" < ver"3.0.0") in
-    withRestartingSparkSession(_
+    withIsolatedSparkSession(_
       .enableHiveSupport
       .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
       .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
@@ -300,7 +300,7 @@ class DeltaDSV2Spec extends AsyncFlatSpec
 
   it should "support MERGE INTO table command" taggedAs
     ignoreIf(ver"$SPARK_VERSION" < ver"3.0.0") in
-    withRestartingSparkSession(_
+    withIsolatedSparkSession(_
       .enableHiveSupport
       .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
       .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")

--- a/integration-tests/src/test/scala/za/co/absa/spline/ElasticSearchSpec.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/ElasticSearchSpec.scala
@@ -43,7 +43,7 @@ class ElasticSearchSpec
       val esPort = container.getFirstMappedPort
       val esOptions = Map("es.nodes" -> esNodes, "es.port" -> esPort.toString, "es.nodes.wan.only" -> "true")
 
-      withSparkSession(implicit spark => {
+      withNewSparkSession(implicit spark => {
         withLineageTracking { captor =>
           val testData: DataFrame = {
             val schema = StructType(StructField("id", IntegerType, nullable = false) :: StructField("name", StringType, nullable = false) :: Nil)

--- a/integration-tests/src/test/scala/za/co/absa/spline/IcebergDSV2Spec.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/IcebergDSV2Spec.scala
@@ -37,7 +37,7 @@ class IcebergDSV2Spec extends AsyncFlatSpec
   private val warehouseUri: URI = TempDirectory(getClass.getSimpleName, "UnitTest", pathOnly = true).deleteOnExit().toURI
 
   it should "support Write to iceberg" taggedAs ignoreIf(ver"$SPARK_VERSION" < ver"3.0.0") in
-    withRestartingSparkSession(_
+    withIsolatedSparkSession(_
       .config("spark.sql.extensions", "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions")
       .config("spark.sql.catalog.iceberg_catalog", "org.apache.iceberg.spark.SparkCatalog")
       .config("spark.sql.catalog.iceberg_catalog.type", "hadoop")
@@ -60,7 +60,7 @@ class IcebergDSV2Spec extends AsyncFlatSpec
     }
 
   it should "support read from iceberg" taggedAs ignoreIf(ver"$SPARK_VERSION" < ver"3.0.0") in
-    withRestartingSparkSession(_
+    withIsolatedSparkSession(_
       .config("spark.sql.extensions", "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions")
       .config("spark.sql.catalog.iceberg_catalog", "org.apache.iceberg.spark.SparkCatalog")
       .config("spark.sql.catalog.iceberg_catalog.type", "hadoop")

--- a/integration-tests/src/test/scala/za/co/absa/spline/InsertIntoHiveTest.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/InsertIntoHiveTest.scala
@@ -35,7 +35,7 @@ class InsertIntoHiveTest
     with SplineFixture {
 
   "InsertInto" should "produce lineage when inserting into Hive table" in
-    withRestartingSparkSession(_.enableHiveSupport()) { implicit spark =>
+    withIsolatedSparkSession(_.enableHiveSupport()) { implicit spark =>
       withLineageTracking { captor =>
         val databaseName = s"unitTestDatabase_${this.getClass.getSimpleName}"
         withDatabase(databaseName,
@@ -67,7 +67,7 @@ class InsertIntoHiveTest
     }
 
   "CsvSerdeTable" should "Produce CatalogTable params" in
-    withRestartingSparkSession(_.enableHiveSupport()) { implicit spark =>
+    withIsolatedSparkSession(_.enableHiveSupport()) { implicit spark =>
       withLineageTracking { captor =>
         withDatabase("test",
           (
@@ -104,7 +104,7 @@ class InsertIntoHiveTest
     }
 
   "ParquetSerdeTable" should "Produce CatalogTable params" in
-    withRestartingSparkSession(_.enableHiveSupport()) { implicit spark =>
+    withIsolatedSparkSession(_.enableHiveSupport()) { implicit spark =>
       withLineageTracking { captor =>
         withDatabase("test",
           (
@@ -139,7 +139,7 @@ class InsertIntoHiveTest
     }
 
   "OrcSerdeTable" should "Produce CatalogTable params" in
-    withRestartingSparkSession(_.enableHiveSupport()) { implicit spark =>
+    withIsolatedSparkSession(_.enableHiveSupport()) { implicit spark =>
       withLineageTracking { captor =>
         withDatabase("test",
           (

--- a/integration-tests/src/test/scala/za/co/absa/spline/InsertIntoHiveTest.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/InsertIntoHiveTest.scala
@@ -18,9 +18,9 @@ package za.co.absa.spline
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.SaveMode._
 import org.apache.spark.sql.functions._
-import org.scalatest.matchers.should.Matchers
 import org.scalatest.OneInstancePerTest
 import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
 import za.co.absa.commons.io.TempDirectory
 import za.co.absa.spline.test.fixture.spline.SplineFixture
 import za.co.absa.spline.test.fixture.spline.SplineFixture.extractTableIdentifier
@@ -35,148 +35,140 @@ class InsertIntoHiveTest
     with SplineFixture {
 
   "InsertInto" should "produce lineage when inserting into Hive table" in
-    withRestartingSparkContext {
-      withCustomSparkSession(_.enableHiveSupport()) { implicit spark =>
-        withLineageTracking { captor =>
-          val databaseName = s"unitTestDatabase_${this.getClass.getSimpleName}"
-          withDatabase(databaseName,
-            ("path_archive", "(x String, ymd int) USING hive", Seq(("Tata", 20190401), ("Tere", 20190403))),
-            ("path", "(x String) USING hive", Seq("Monika", "Buba"))
-          ) {
-            val df = spark
-              .table("path")
-              .withColumn("ymd", lit(20190401))
+    withRestartingSparkSession(_.enableHiveSupport()) { implicit spark =>
+      withLineageTracking { captor =>
+        val databaseName = s"unitTestDatabase_${this.getClass.getSimpleName}"
+        withDatabase(databaseName,
+          ("path_archive", "(x String, ymd int) USING hive", Seq(("Tata", 20190401), ("Tere", 20190403))),
+          ("path", "(x String) USING hive", Seq("Monika", "Buba"))
+        ) {
+          val df = spark
+            .table("path")
+            .withColumn("ymd", lit(20190401))
 
 
-            for {
-              (plan1, _) <- captor.lineageOf {
-                df.write.mode(Append).insertInto("path_archive")
-              }
-
-              (plan2, _) <- captor.lineageOf {
-                spark
-                  .read.table("path_archive")
-                  .write.csv(TempDirectory(pathOnly = true).deleteOnExit().path.toString)
-              }
-            } yield {
-              plan1.operations.write.append should be(true)
-              plan1.operations.write.outputSource should be(s"$warehouseUri/${databaseName.toLowerCase}.db/path_archive")
-              plan2.operations.reads.head.inputSources.head shouldEqual plan1.operations.write.outputSource
+          for {
+            (plan1, _) <- captor.lineageOf {
+              df.write.mode(Append).insertInto("path_archive")
             }
+
+            (plan2, _) <- captor.lineageOf {
+              spark
+                .read.table("path_archive")
+                .write.csv(TempDirectory(pathOnly = true).deleteOnExit().path.toString)
+            }
+          } yield {
+            plan1.operations.write.append should be(true)
+            plan1.operations.write.outputSource should be(s"$warehouseUri/${databaseName.toLowerCase}.db/path_archive")
+            plan2.operations.reads.head.inputSources.head shouldEqual plan1.operations.write.outputSource
           }
         }
       }
     }
 
   "CsvSerdeTable" should "Produce CatalogTable params" in
-    withRestartingSparkContext {
-      withCustomSparkSession(_.enableHiveSupport()) { implicit spark =>
-        withLineageTracking { captor =>
-          withDatabase("test",
-            (
-              "path_archive_csvserde",
-              "(x String, ymd int) ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.OpenCSVSerde'",
-              Seq(("Tata", 20190401), ("Tere", 20190403))
-            ),
-            (
-              "path_csvserde",
-              "(x String) ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.OpenCSVSerde'",
-              Seq("Monika", "Buba")
-            )
-          ) {
-            val df = spark
-              .table("test.path_csvserde")
-              .withColumn("ymd", lit(20190401))
+    withRestartingSparkSession(_.enableHiveSupport()) { implicit spark =>
+      withLineageTracking { captor =>
+        withDatabase("test",
+          (
+            "path_archive_csvserde",
+            "(x String, ymd int) ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.OpenCSVSerde'",
+            Seq(("Tata", 20190401), ("Tere", 20190403))
+          ),
+          (
+            "path_csvserde",
+            "(x String) ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.OpenCSVSerde'",
+            Seq("Monika", "Buba")
+          )
+        ) {
+          val df = spark
+            .table("test.path_csvserde")
+            .withColumn("ymd", lit(20190401))
 
-            for {
-              (plan, _) <- captor.lineageOf {
-                df.write.mode(SaveMode.Overwrite).insertInto("test.path_archive_csvserde")
-              }
-            } yield {
-              plan.operations.write.outputSource should include("path_archive")
-              plan.operations.write.append should be(false)
-              val writeTable = extractTableIdentifier(plan.operations.write.params)
-              val readTable = extractTableIdentifier(plan.operations.reads.head.params)
-              writeTable("table") should be("path_archive_csvserde")
-              writeTable("database") should be(Some("test"))
-              readTable("table") should be("path_csvserde")
-              readTable("database") should be(Some("test"))
+          for {
+            (plan, _) <- captor.lineageOf {
+              df.write.mode(SaveMode.Overwrite).insertInto("test.path_archive_csvserde")
             }
+          } yield {
+            plan.operations.write.outputSource should include("path_archive")
+            plan.operations.write.append should be(false)
+            val writeTable = extractTableIdentifier(plan.operations.write.params)
+            val readTable = extractTableIdentifier(plan.operations.reads.head.params)
+            writeTable("table") should be("path_archive_csvserde")
+            writeTable("database") should be(Some("test"))
+            readTable("table") should be("path_csvserde")
+            readTable("database") should be(Some("test"))
           }
         }
       }
     }
 
   "ParquetSerdeTable" should "Produce CatalogTable params" in
-    withRestartingSparkContext {
-      withCustomSparkSession(_.enableHiveSupport()) { implicit spark =>
-        withLineageTracking { captor =>
-          withDatabase("test",
-            (
-              "path_archive_parquetserde", "(x String, ymd int) stored as PARQUET",
-              Seq(("Tata", 20190401), ("Tere", 20190403))
-            ),
-            (
-              "path_parquetserde", "(x String) stored as PARQUET",
-              Seq("Monika", "Buba")
-            )
-          ) {
-            val df = spark
-              .table("test.path_parquetserde")
-              .withColumn("ymd", lit(20190401))
+    withRestartingSparkSession(_.enableHiveSupport()) { implicit spark =>
+      withLineageTracking { captor =>
+        withDatabase("test",
+          (
+            "path_archive_parquetserde", "(x String, ymd int) stored as PARQUET",
+            Seq(("Tata", 20190401), ("Tere", 20190403))
+          ),
+          (
+            "path_parquetserde", "(x String) stored as PARQUET",
+            Seq("Monika", "Buba")
+          )
+        ) {
+          val df = spark
+            .table("test.path_parquetserde")
+            .withColumn("ymd", lit(20190401))
 
-            for {
-              (plan, _) <- captor.lineageOf {
-                df.write.mode(SaveMode.Overwrite).insertInto("test.path_archive_parquetserde")
-              }
-            } yield {
-              plan.operations.write.outputSource should include("path_archive")
-              plan.operations.write.append should be(false)
-              val writeTable = extractTableIdentifier(plan.operations.write.params)
-              val readTable = extractTableIdentifier(plan.operations.reads.head.params)
-              writeTable("table") should be("path_archive_parquetserde")
-              writeTable("database") should be(Some("test"))
-              readTable("table") should be("path_parquetserde")
-              readTable("database") should be(Some("test"))
+          for {
+            (plan, _) <- captor.lineageOf {
+              df.write.mode(SaveMode.Overwrite).insertInto("test.path_archive_parquetserde")
             }
+          } yield {
+            plan.operations.write.outputSource should include("path_archive")
+            plan.operations.write.append should be(false)
+            val writeTable = extractTableIdentifier(plan.operations.write.params)
+            val readTable = extractTableIdentifier(plan.operations.reads.head.params)
+            writeTable("table") should be("path_archive_parquetserde")
+            writeTable("database") should be(Some("test"))
+            readTable("table") should be("path_parquetserde")
+            readTable("database") should be(Some("test"))
           }
         }
       }
     }
 
   "OrcSerdeTable" should "Produce CatalogTable params" in
-    withRestartingSparkContext {
-      withCustomSparkSession(_.enableHiveSupport()) { implicit spark =>
-        withLineageTracking { captor =>
-          withDatabase("test",
-            (
-              "path_archive_orcserde", "(x String, ymd int) stored as orc",
-              Seq(("Tata", 20190401), ("Tere", 20190403))
-            ),
-            (
-              "path_orcserde", "(x String) stored as orc",
-              Seq("Monika", "Buba")
-            )
-          ) {
-            val df = spark
-              .table("test.path_orcserde")
-              .withColumn("ymd", lit(20190401))
+    withRestartingSparkSession(_.enableHiveSupport()) { implicit spark =>
+      withLineageTracking { captor =>
+        withDatabase("test",
+          (
+            "path_archive_orcserde", "(x String, ymd int) stored as orc",
+            Seq(("Tata", 20190401), ("Tere", 20190403))
+          ),
+          (
+            "path_orcserde", "(x String) stored as orc",
+            Seq("Monika", "Buba")
+          )
+        ) {
+          val df = spark
+            .table("test.path_orcserde")
+            .withColumn("ymd", lit(20190401))
 
-            for {
-              (plan, _) <- captor.lineageOf {
-                df.write.mode(SaveMode.Overwrite).insertInto("test.path_archive_orcserde")
-              }
-            } yield {
-              plan.operations.write.outputSource should include("path_archive")
-              plan.operations.write.append should be(false)
-
-              val writeTable = extractTableIdentifier(plan.operations.write.params)
-              val readTable = extractTableIdentifier(plan.operations.reads.head.params)
-              writeTable("table") should be("path_archive_orcserde")
-              writeTable("database") should be(Some("test"))
-              readTable("table") should be("path_orcserde")
-              readTable("database") should be(Some("test"))
+          for {
+            (plan, _) <- captor.lineageOf {
+              df.write.mode(SaveMode.Overwrite).insertInto("test.path_archive_orcserde")
             }
+          } yield {
+            plan.operations.write.outputSource should include("path_archive")
+            plan.operations.write.append should be(false)
+
+            val writeTable = extractTableIdentifier(plan.operations.write.params)
+            val readTable = extractTableIdentifier(plan.operations.reads.head.params)
+            writeTable("table") should be("path_archive_orcserde")
+            writeTable("database") should be(Some("test"))
+            readTable("table") should be("path_orcserde")
+            readTable("database") should be(Some("test"))
           }
         }
       }

--- a/integration-tests/src/test/scala/za/co/absa/spline/InsertIntoHiveTest.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/InsertIntoHiveTest.scala
@@ -59,7 +59,7 @@ class InsertIntoHiveTest
             }
           } yield {
             plan1.operations.write.append should be(true)
-            plan1.operations.write.outputSource should be(s"$warehouseUri/${databaseName.toLowerCase}.db/path_archive")
+            plan1.operations.write.outputSource should endWith(s"/${databaseName.toLowerCase}.db/path_archive")
             plan2.operations.reads.head.inputSources.head shouldEqual plan1.operations.write.outputSource
           }
         }

--- a/integration-tests/src/test/scala/za/co/absa/spline/InsertIntoTest.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/InsertIntoTest.scala
@@ -32,162 +32,152 @@ class InsertIntoTest extends AsyncFlatSpec
   with SparkDatabaseFixture {
 
   "InsertInto" should "not fail when inserting to partitioned table created as Spark tables" in
-    withRestartingSparkContext {
-      withCustomSparkSession(_.enableHiveSupport()) { implicit spark =>
-        withLineageTracking { captor =>
-          withDatabase("test",
-            ("path_archive", "(x String, ymd int) USING json PARTITIONED BY (ymd)",
-              Seq(("Tata", 20190401), ("Tere", 20190403))),
-            ("path", "(x String) USING json",
-              Seq("Monika", "Buba"))
-          ) {
+    withRestartingSparkSession(_.enableHiveSupport()) { implicit spark =>
+      withLineageTracking { captor =>
+        withDatabase("test",
+          ("path_archive", "(x String, ymd int) USING json PARTITIONED BY (ymd)",
+            Seq(("Tata", 20190401), ("Tere", 20190403))),
+          ("path", "(x String) USING json",
+            Seq("Monika", "Buba"))
+        ) {
 
-            val df = spark
-              .table("test.path")
-              .withColumn("ymd", lit(20190401))
+          val df = spark
+            .table("test.path")
+            .withColumn("ymd", lit(20190401))
 
-            for {
-              (plan, _) <- captor.lineageOf {
-                df.write.mode(SaveMode.Overwrite).insertInto("test.path_archive")
-              }
-            } yield {
-              plan.operations.write.outputSource should include("path_archive")
-              plan.operations.write.append should be(false)
+          for {
+            (plan, _) <- captor.lineageOf {
+              df.write.mode(SaveMode.Overwrite).insertInto("test.path_archive")
             }
+          } yield {
+            plan.operations.write.outputSource should include("path_archive")
+            plan.operations.write.append should be(false)
           }
         }
       }
     }
 
   "ParquetTable" should "Produce CatalogTable params" in
-    withRestartingSparkContext {
-      withCustomSparkSession(_.enableHiveSupport()) { implicit spark =>
-        withLineageTracking { captor =>
-          withDatabase("test",
-            ("path_archive", "(x String, ymd int) USING parquet PARTITIONED BY (ymd)",
-              Seq(("Tata", 20190401), ("Tere", 20190403))),
-            ("path", "(x String) USING parquet",
-              Seq("Monika", "Buba"))
-          ) {
-            val df = spark
-              .table("test.path")
-              .withColumn("ymd", lit(20190401))
+    withRestartingSparkSession(_.enableHiveSupport()) { implicit spark =>
+      withLineageTracking { captor =>
+        withDatabase("test",
+          ("path_archive", "(x String, ymd int) USING parquet PARTITIONED BY (ymd)",
+            Seq(("Tata", 20190401), ("Tere", 20190403))),
+          ("path", "(x String) USING parquet",
+            Seq("Monika", "Buba"))
+        ) {
+          val df = spark
+            .table("test.path")
+            .withColumn("ymd", lit(20190401))
 
-            for {
-              (plan, _) <- captor.lineageOf {
-                df.write.mode(SaveMode.Overwrite).insertInto("test.path_archive")
-              }
-            } yield {
-              plan.operations.write.outputSource should include("path_archive")
-              plan.operations.write.append should be(false)
-              val writeTable = extractTableIdentifier(plan.operations.write.params)
-              val readTable = extractTableIdentifier(plan.operations.reads.head.params)
-              writeTable("table") should be("path_archive")
-              writeTable("database") should be(Some("test"))
-              readTable("table") should be("path")
-              readTable("database") should be(Some("test"))
+          for {
+            (plan, _) <- captor.lineageOf {
+              df.write.mode(SaveMode.Overwrite).insertInto("test.path_archive")
             }
+          } yield {
+            plan.operations.write.outputSource should include("path_archive")
+            plan.operations.write.append should be(false)
+            val writeTable = extractTableIdentifier(plan.operations.write.params)
+            val readTable = extractTableIdentifier(plan.operations.reads.head.params)
+            writeTable("table") should be("path_archive")
+            writeTable("database") should be(Some("test"))
+            readTable("table") should be("path")
+            readTable("database") should be(Some("test"))
           }
         }
       }
     }
 
   "CsvTable" should "Produce CatalogTable params" in
-    withRestartingSparkContext {
-      withCustomSparkSession(_.enableHiveSupport()) { implicit spark =>
-        withLineageTracking { captor =>
-          withDatabase("test",
-            ("path_archive", "(x String, ymd int) USING csv PARTITIONED BY (ymd)",
-              Seq(("Tata", 20190401), ("Tere", 20190403))),
-            ("path", "(x String) USING csv",
-              Seq("Monika", "Buba"))
-          ) {
-            val df = spark
-              .table("test.path")
-              .withColumn("ymd", lit(20190401))
+    withRestartingSparkSession(_.enableHiveSupport()) { implicit spark =>
+      withLineageTracking { captor =>
+        withDatabase("test",
+          ("path_archive", "(x String, ymd int) USING csv PARTITIONED BY (ymd)",
+            Seq(("Tata", 20190401), ("Tere", 20190403))),
+          ("path", "(x String) USING csv",
+            Seq("Monika", "Buba"))
+        ) {
+          val df = spark
+            .table("test.path")
+            .withColumn("ymd", lit(20190401))
 
-            for {
-              (plan, _) <- captor.lineageOf {
-                df.write.mode(SaveMode.Overwrite).insertInto("test.path_archive")
-              }
-            } yield {
-              plan.operations.write.outputSource should include("path_archive")
-              plan.operations.write.append should be(false)
-              val writeTable = extractTableIdentifier(plan.operations.write.params)
-              val readTable = extractTableIdentifier(plan.operations.reads.head.params)
-              writeTable("table") should be("path_archive")
-              writeTable("database") should be(Some("test"))
-              readTable("table") should be("path")
-              readTable("database") should be(Some("test"))
+          for {
+            (plan, _) <- captor.lineageOf {
+              df.write.mode(SaveMode.Overwrite).insertInto("test.path_archive")
             }
+          } yield {
+            plan.operations.write.outputSource should include("path_archive")
+            plan.operations.write.append should be(false)
+            val writeTable = extractTableIdentifier(plan.operations.write.params)
+            val readTable = extractTableIdentifier(plan.operations.reads.head.params)
+            writeTable("table") should be("path_archive")
+            writeTable("database") should be(Some("test"))
+            readTable("table") should be("path")
+            readTable("database") should be(Some("test"))
           }
         }
       }
     }
 
   "JsonTable" should "Produce CatalogTable params" in
-    withRestartingSparkContext {
-      withCustomSparkSession(_.enableHiveSupport()) { implicit spark =>
-        withLineageTracking { captor =>
-          withDatabase("test",
-            ("path_archive", "(x String, ymd int) USING json PARTITIONED BY (ymd)",
-              Seq(("Tata", 20190401), ("Tere", 20190403))),
-            ("path", "(x String) USING json",
-              Seq("Monika", "Buba"))
-          ) {
-            val df = spark
-              .table("test.path")
-              .withColumn("ymd", lit(20190401))
+    withRestartingSparkSession(_.enableHiveSupport()) { implicit spark =>
+      withLineageTracking { captor =>
+        withDatabase("test",
+          ("path_archive", "(x String, ymd int) USING json PARTITIONED BY (ymd)",
+            Seq(("Tata", 20190401), ("Tere", 20190403))),
+          ("path", "(x String) USING json",
+            Seq("Monika", "Buba"))
+        ) {
+          val df = spark
+            .table("test.path")
+            .withColumn("ymd", lit(20190401))
 
-            for {
-              (plan, _) <- captor.lineageOf {
-                df.write.mode(SaveMode.Overwrite).insertInto("test.path_archive")
-              }
-            } yield {
-
-              plan.operations.write.outputSource should include("path_archive")
-              plan.operations.write.append should be(false)
-              val writeTable = extractTableIdentifier(plan.operations.write.params)
-              val readTable = extractTableIdentifier(plan.operations.reads.head.params)
-              writeTable("table") should be("path_archive")
-              writeTable("database") should be(Some("test"))
-              readTable("table") should be("path")
-              readTable("database") should be(Some("test"))
+          for {
+            (plan, _) <- captor.lineageOf {
+              df.write.mode(SaveMode.Overwrite).insertInto("test.path_archive")
             }
+          } yield {
+
+            plan.operations.write.outputSource should include("path_archive")
+            plan.operations.write.append should be(false)
+            val writeTable = extractTableIdentifier(plan.operations.write.params)
+            val readTable = extractTableIdentifier(plan.operations.reads.head.params)
+            writeTable("table") should be("path_archive")
+            writeTable("database") should be(Some("test"))
+            readTable("table") should be("path")
+            readTable("database") should be(Some("test"))
           }
         }
       }
     }
 
   "ORCTable" should "Produce CatalogTable params" in
-    withRestartingSparkContext {
-      withCustomSparkSession(_.enableHiveSupport()) { implicit spark =>
-        withLineageTracking { captor =>
-          withDatabase("test",
-            ("path_archive", "(x String, ymd int) USING orc PARTITIONED BY (ymd)",
-              Seq(("Tata", 20190401), ("Tere", 20190403))),
-            ("path", "(x String) USING orc",
-              Seq("Monika", "Buba"))
-          ) {
+    withRestartingSparkSession(_.enableHiveSupport()) { implicit spark =>
+      withLineageTracking { captor =>
+        withDatabase("test",
+          ("path_archive", "(x String, ymd int) USING orc PARTITIONED BY (ymd)",
+            Seq(("Tata", 20190401), ("Tere", 20190403))),
+          ("path", "(x String) USING orc",
+            Seq("Monika", "Buba"))
+        ) {
 
-            val df = spark
-              .table("test.path")
-              .withColumn("ymd", lit(20190401))
+          val df = spark
+            .table("test.path")
+            .withColumn("ymd", lit(20190401))
 
-            for {
-              (plan, _) <- captor.lineageOf {
-                df.write.mode(SaveMode.Overwrite).insertInto("test.path_archive")
-              }
-            } yield {
-              plan.operations.write.outputSource should include("path_archive")
-              plan.operations.write.append should be(false)
-              val writeTable = extractTableIdentifier(plan.operations.write.params)
-              val readTable = extractTableIdentifier(plan.operations.reads.head.params)
-              writeTable("table") should be("path_archive")
-              writeTable("database") should be(Some("test"))
-              readTable("table") should be("path")
-              readTable("database") should be(Some("test"))
+          for {
+            (plan, _) <- captor.lineageOf {
+              df.write.mode(SaveMode.Overwrite).insertInto("test.path_archive")
             }
+          } yield {
+            plan.operations.write.outputSource should include("path_archive")
+            plan.operations.write.append should be(false)
+            val writeTable = extractTableIdentifier(plan.operations.write.params)
+            val readTable = extractTableIdentifier(plan.operations.reads.head.params)
+            writeTable("table") should be("path_archive")
+            writeTable("database") should be(Some("test"))
+            readTable("table") should be("path")
+            readTable("database") should be(Some("test"))
           }
         }
       }

--- a/integration-tests/src/test/scala/za/co/absa/spline/InsertIntoTest.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/InsertIntoTest.scala
@@ -32,7 +32,7 @@ class InsertIntoTest extends AsyncFlatSpec
   with SparkDatabaseFixture {
 
   "InsertInto" should "not fail when inserting to partitioned table created as Spark tables" in
-    withRestartingSparkSession(_.enableHiveSupport()) { implicit spark =>
+    withIsolatedSparkSession(_.enableHiveSupport()) { implicit spark =>
       withLineageTracking { captor =>
         withDatabase("test",
           ("path_archive", "(x String, ymd int) USING json PARTITIONED BY (ymd)",
@@ -58,7 +58,7 @@ class InsertIntoTest extends AsyncFlatSpec
     }
 
   "ParquetTable" should "Produce CatalogTable params" in
-    withRestartingSparkSession(_.enableHiveSupport()) { implicit spark =>
+    withIsolatedSparkSession(_.enableHiveSupport()) { implicit spark =>
       withLineageTracking { captor =>
         withDatabase("test",
           ("path_archive", "(x String, ymd int) USING parquet PARTITIONED BY (ymd)",
@@ -89,7 +89,7 @@ class InsertIntoTest extends AsyncFlatSpec
     }
 
   "CsvTable" should "Produce CatalogTable params" in
-    withRestartingSparkSession(_.enableHiveSupport()) { implicit spark =>
+    withIsolatedSparkSession(_.enableHiveSupport()) { implicit spark =>
       withLineageTracking { captor =>
         withDatabase("test",
           ("path_archive", "(x String, ymd int) USING csv PARTITIONED BY (ymd)",
@@ -120,7 +120,7 @@ class InsertIntoTest extends AsyncFlatSpec
     }
 
   "JsonTable" should "Produce CatalogTable params" in
-    withRestartingSparkSession(_.enableHiveSupport()) { implicit spark =>
+    withIsolatedSparkSession(_.enableHiveSupport()) { implicit spark =>
       withLineageTracking { captor =>
         withDatabase("test",
           ("path_archive", "(x String, ymd int) USING json PARTITIONED BY (ymd)",
@@ -152,7 +152,7 @@ class InsertIntoTest extends AsyncFlatSpec
     }
 
   "ORCTable" should "Produce CatalogTable params" in
-    withRestartingSparkSession(_.enableHiveSupport()) { implicit spark =>
+    withIsolatedSparkSession(_.enableHiveSupport()) { implicit spark =>
       withLineageTracking { captor =>
         withDatabase("test",
           ("path_archive", "(x String, ymd int) USING orc PARTITIONED BY (ymd)",

--- a/integration-tests/src/test/scala/za/co/absa/spline/JsonDSV2Spec.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/JsonDSV2Spec.scala
@@ -40,7 +40,7 @@ class JsonDSV2Spec extends AsyncFlatSpec
   val jsonDir: String = TempDirectory("SparkFixture", "UnitTestJson", pathOnly = true).deleteOnExit().path.toString.stripSuffix("/")
 
   it should "support json V2 command" taggedAs ignoreIf(ver"$SPARK_VERSION" < ver"3.0.0") in
-    withCustomSparkSession(_
+    withRestartingSparkSession(_
       .config("spark.sql.sources.useV1SourceList", "") // use V2 by default
     ) { implicit spark =>
       withLineageTracking { lineageCaptor =>

--- a/integration-tests/src/test/scala/za/co/absa/spline/JsonDSV2Spec.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/JsonDSV2Spec.scala
@@ -40,7 +40,7 @@ class JsonDSV2Spec extends AsyncFlatSpec
   val jsonDir: String = TempDirectory("SparkFixture", "UnitTestJson", pathOnly = true).deleteOnExit().path.toString.stripSuffix("/")
 
   it should "support json V2 command" taggedAs ignoreIf(ver"$SPARK_VERSION" < ver"3.0.0") in
-    withRestartingSparkSession(_
+    withIsolatedSparkSession(_
       .config("spark.sql.sources.useV1SourceList", "") // use V2 by default
     ) { implicit spark =>
       withLineageTracking { lineageCaptor =>

--- a/integration-tests/src/test/scala/za/co/absa/spline/NonPersistentActionsSpec.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/NonPersistentActionsSpec.scala
@@ -39,22 +39,20 @@ class NonPersistentActionsSpec extends AsyncFlatSpec
     )
   ) yield {
     it should s"capture lineage from the `$methodName()` action" in
-      withRestartingSparkContext {
-        withCustomSparkSession(_.config(NonPersistentActionsPluginEnabledProperty, value = true)) { implicit spark =>
-          withLineageTracking { captor =>
-            for {
-              (plan, _) <- captor.lineageOf {
-                import spark.implicits._
-                val df1 = Seq((1, 2, 3)).toDF()
-                action(df1)
-              }
-            } yield {
-              plan.operations.write.append shouldBe false
-              plan.operations.write.name shouldEqual expectedCommandName
-              plan.operations.write.extra should contain("synthetic" -> true)
-              plan.operations.write.outputSource should startWith("memory://")
-              plan.operations.write.outputSource should include("jvm_")
+      withRestartingSparkSession(_.config(NonPersistentActionsPluginEnabledProperty, value = true)) { implicit spark =>
+        withLineageTracking { captor =>
+          for {
+            (plan, _) <- captor.lineageOf {
+              import spark.implicits._
+              val df1 = Seq((1, 2, 3)).toDF()
+              action(df1)
             }
+          } yield {
+            plan.operations.write.append shouldBe false
+            plan.operations.write.name shouldEqual expectedCommandName
+            plan.operations.write.extra should contain("synthetic" -> true)
+            plan.operations.write.outputSource should startWith("memory://")
+            plan.operations.write.outputSource should include("jvm_")
           }
         }
       }

--- a/integration-tests/src/test/scala/za/co/absa/spline/NonPersistentActionsSpec.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/NonPersistentActionsSpec.scala
@@ -39,7 +39,7 @@ class NonPersistentActionsSpec extends AsyncFlatSpec
     )
   ) yield {
     it should s"capture lineage from the `$methodName()` action" in
-      withRestartingSparkSession(_.config(NonPersistentActionsPluginEnabledProperty, value = true)) { implicit spark =>
+      withIsolatedSparkSession(_.config(NonPersistentActionsPluginEnabledProperty, value = true)) { implicit spark =>
         withLineageTracking { captor =>
           for {
             (plan, _) <- captor.lineageOf {

--- a/integration-tests/src/test/scala/za/co/absa/spline/OneRowRelationFilterSpec.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/OneRowRelationFilterSpec.scala
@@ -28,24 +28,22 @@ class OneRowRelationFilterSpec extends AsyncFlatSpec
   with SparkDatabaseFixture {
 
   it should "produce lineage without OneRowRelation operation" in
-    withRestartingSparkContext {
-      withSparkSession { implicit spark =>
-        withLineageTracking { lineageCaptor =>
-          withDatabase("testDB") {
-            for {
-              (plan, _) <- lineageCaptor.lineageOf {
-                spark
-                  .sql("SELECT 'Green' AS data_quality_status, 'Batch Started' AS batch_status")
-                  .write
-                  .saveAsTable("t1")
-              }
-            } yield {
-              val Seq(op) = plan.operations.other
-
-              op.name should be("Project")
-              op.childIds should be(Seq.empty)
-              op.output.size should be(2)
+    withRestartingSparkSession() { implicit spark =>
+      withLineageTracking { lineageCaptor =>
+        withDatabase("testDB") {
+          for {
+            (plan, _) <- lineageCaptor.lineageOf {
+              spark
+                .sql("SELECT 'Green' AS data_quality_status, 'Batch Started' AS batch_status")
+                .write
+                .saveAsTable("t1")
             }
+          } yield {
+            val Seq(op) = plan.operations.other
+
+            op.name should be("Project")
+            op.childIds should be(Seq.empty)
+            op.output.size should be(2)
           }
         }
       }

--- a/integration-tests/src/test/scala/za/co/absa/spline/OneRowRelationFilterSpec.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/OneRowRelationFilterSpec.scala
@@ -28,7 +28,7 @@ class OneRowRelationFilterSpec extends AsyncFlatSpec
   with SparkDatabaseFixture {
 
   it should "produce lineage without OneRowRelation operation" in
-    withRestartingSparkSession() { implicit spark =>
+    withIsolatedSparkSession() { implicit spark =>
       withLineageTracking { lineageCaptor =>
         withDatabase("testDB") {
           for {

--- a/integration-tests/src/test/scala/za/co/absa/spline/SQLCommandsSpec.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/SQLCommandsSpec.scala
@@ -59,9 +59,9 @@ class SQLCommandsSpec extends AsyncFlatSpec
                 | WHERE id > 1""".stripMargin))
 
         } yield {
-          plan1.operations.write.outputSource should equalToUri(s"$warehouseUri/sourcetable")
-          plan2.operations.reads.head.inputSources.head should equalToUri(plan1.operations.write.outputSource)
-          plan2.operations.write.outputSource should equalToUri(s"$warehouseUri/targettable")
+          plan1.operations.write.outputSource should endWith("/sourcetable")
+          plan2.operations.reads.head.inputSources.head shouldBe plan1.operations.write.outputSource
+          plan2.operations.write.outputSource should endWith("/targettable")
         }
       }
     }
@@ -89,7 +89,7 @@ class SQLCommandsSpec extends AsyncFlatSpec
                  | FROM sourceTable
                  | WHERE id > 1""".stripMargin))
         } yield {
-          plan.operations.reads.head.inputSources.head should equalToUri(s"$warehouseUri/sourcetable")
+          plan.operations.reads.head.inputSources.head should endWith("/sourcetable")
           plan.operations.write.outputSource should equalToUri(dir.toUri.toString.stripSuffix("/"))
         }
       }
@@ -122,7 +122,7 @@ class SQLCommandsSpec extends AsyncFlatSpec
                  | WHERE id > 1""".stripMargin)
           )
         } yield {
-          plan.operations.reads.head.inputSources.head should equalToUri(s"$warehouseUri/sourcetable")
+          plan.operations.reads.head.inputSources.head should endWith("/sourcetable")
           plan.operations.write.outputSource should equalToUri(csvFile.toUri.toString.stripSuffix("/"))
         }
       }

--- a/integration-tests/src/test/scala/za/co/absa/spline/SQLCommandsSpec.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/SQLCommandsSpec.scala
@@ -38,98 +38,92 @@ class SQLCommandsSpec extends AsyncFlatSpec
   behavior of "spark.sql()"
 
   it should "capture lineage of 'CREATE TABLE AS` - Hive" taggedAs ignoreIf(ver"$SPARK_VERSION" < ver"2.3") in
-    withRestartingSparkContext {
-      withCustomSparkSession(_.enableHiveSupport) { implicit spark =>
-        withLineageTracking { captor =>
-          import spark.implicits._
+    withRestartingSparkSession(_.enableHiveSupport) { implicit spark =>
+      withLineageTracking { captor =>
+        import spark.implicits._
 
-          for {
-            (_, _) <- captor.lineageOf(
-              spark.sql("CREATE TABLE sourceTable (id int, name string)"))
+        for {
+          (_, _) <- captor.lineageOf(
+            spark.sql("CREATE TABLE sourceTable (id int, name string)"))
 
-            (plan1, _) <- captor.lineageOf(
-              Seq((1, "AA"), (2, "BB"), (3, "CC"), (4, "DD"))
-                .toDF("id", "name")
-                .write.mode(Overwrite).insertInto("sourceTable"))
+          (plan1, _) <- captor.lineageOf(
+            Seq((1, "AA"), (2, "BB"), (3, "CC"), (4, "DD"))
+              .toDF("id", "name")
+              .write.mode(Overwrite).insertInto("sourceTable"))
 
-            (plan2, _) <- captor.lineageOf(
-              spark.sql(
-                """CREATE TABLE targetTable AS
-                  | SELECT id, name
-                  | FROM sourceTable
-                  | WHERE id > 1""".stripMargin))
+          (plan2, _) <- captor.lineageOf(
+            spark.sql(
+              """CREATE TABLE targetTable AS
+                | SELECT id, name
+                | FROM sourceTable
+                | WHERE id > 1""".stripMargin))
 
-          } yield {
-            plan1.operations.write.outputSource should equalToUri(s"$warehouseUri/sourcetable")
-            plan2.operations.reads.head.inputSources.head should equalToUri(plan1.operations.write.outputSource)
-            plan2.operations.write.outputSource should equalToUri(s"$warehouseUri/targettable")
-          }
+        } yield {
+          plan1.operations.write.outputSource should equalToUri(s"$warehouseUri/sourcetable")
+          plan2.operations.reads.head.inputSources.head should equalToUri(plan1.operations.write.outputSource)
+          plan2.operations.write.outputSource should equalToUri(s"$warehouseUri/targettable")
         }
       }
     }
 
   it should "capture lineage of 'INSERT OVERWRITE AS` - Hive" taggedAs ignoreIf(ver"$SPARK_VERSION" < ver"2.3") in
-    withRestartingSparkContext {
-      withCustomSparkSession(_.enableHiveSupport) { implicit spark =>
-        withLineageTracking { captor =>
-          import spark.implicits._
+    withRestartingSparkSession(_.enableHiveSupport) { implicit spark =>
+      withLineageTracking { captor =>
+        import spark.implicits._
 
-          val dir = TempDirectory("spline", ".table", pathOnly = true).deleteOnExit().path
+        val dir = TempDirectory("spline", ".table", pathOnly = true).deleteOnExit().path
 
-          withNewSparkSession { innerSpark =>
-            innerSpark.sql("CREATE TABLE IF NOT EXISTS sourceTable (id int, name string)")
-          }
+        withNewSparkSession { innerSpark =>
+          innerSpark.sql("CREATE TABLE IF NOT EXISTS sourceTable (id int, name string)")
+        }
 
-          for {
-            (_, _) <- captor.lineageOf(
-              Seq((1, "AA"), (2, "BB"), (3, "CC"), (4, "DD"))
-                .toDF("id", "name")
-                .write.mode(Overwrite).insertInto("sourceTable"))
-            (plan, _) <- captor.lineageOf(
-              spark.sql(
-                s"""INSERT OVERWRITE DIRECTORY '${dir.toUri}'
-                   | SELECT id, name
-                   | FROM sourceTable
-                   | WHERE id > 1""".stripMargin))
-          } yield {
-            plan.operations.reads.head.inputSources.head should equalToUri(s"$warehouseUri/sourcetable")
-            plan.operations.write.outputSource should equalToUri(dir.toUri.toString.stripSuffix("/"))
-          }
+        for {
+          (_, _) <- captor.lineageOf(
+            Seq((1, "AA"), (2, "BB"), (3, "CC"), (4, "DD"))
+              .toDF("id", "name")
+              .write.mode(Overwrite).insertInto("sourceTable"))
+          (plan, _) <- captor.lineageOf(
+            spark.sql(
+              s"""INSERT OVERWRITE DIRECTORY '${dir.toUri}'
+                 | SELECT id, name
+                 | FROM sourceTable
+                 | WHERE id > 1""".stripMargin))
+        } yield {
+          plan.operations.reads.head.inputSources.head should equalToUri(s"$warehouseUri/sourcetable")
+          plan.operations.write.outputSource should equalToUri(dir.toUri.toString.stripSuffix("/"))
         }
       }
     }
 
   it should "capture lineage of 'INSERT OVERWRITE AS` - non-Hive" taggedAs ignoreIf(ver"$SPARK_VERSION" < ver"2.3") in
-    withRestartingSparkContext {
-      withCustomSparkSession(_.enableHiveSupport) { implicit spark =>
-        withLineageTracking { captor =>
-          import spark.implicits._
+    withRestartingSparkSession(_.enableHiveSupport) { implicit spark =>
+      withLineageTracking { captor =>
+        import spark.implicits._
 
-          val csvFile = TempDirectory("spline", ".csv").deleteOnExit().path
+        val csvFile = TempDirectory("spline", ".csv").deleteOnExit().path
 
-          withNewSparkSession{ innerSpark =>
-            innerSpark.sql("CREATE TABLE sourceTable (id int, name string)")
-          }
+        withNewSparkSession { innerSpark =>
+          innerSpark.sql("CREATE TABLE sourceTable (id int, name string)")
+        }
 
-          for {
-            (_, _) <- captor.lineageOf(
-              Seq((1, "AA"), (2, "BB"), (3, "CC"), (4, "DD"))
-                .toDF("id", "name")
-                .write.insertInto("sourceTable")
-            )
+        for {
+          (_, _) <- captor.lineageOf(
+            Seq((1, "AA"), (2, "BB"), (3, "CC"), (4, "DD"))
+              .toDF("id", "name")
+              .write.insertInto("sourceTable")
+          )
 
-            (plan, _) <- captor.lineageOf(
-              spark.sql(
-                s"""INSERT OVERWRITE DIRECTORY '${csvFile.toUri}'
-                   | USING CSV
-                   | SELECT id, name
-                   | FROM sourceTable
-                   | WHERE id > 1""".stripMargin)
-            )
-          } yield {
-            plan.operations.reads.head.inputSources.head should equalToUri(s"$warehouseUri/sourcetable")
-            plan.operations.write.outputSource should equalToUri(csvFile.toUri.toString.stripSuffix("/"))
-          }
+          (plan, _) <- captor.lineageOf(
+            spark.sql(
+              s"""INSERT OVERWRITE DIRECTORY '${csvFile.toUri}'
+                 | USING CSV
+                 | SELECT id, name
+                 | FROM sourceTable
+                 | WHERE id > 1""".stripMargin)
+          )
+        } yield {
+          plan.operations.reads.head.inputSources.head should equalToUri(s"$warehouseUri/sourcetable")
+          plan.operations.write.outputSource should equalToUri(csvFile.toUri.toString.stripSuffix("/"))
         }
       }
     }

--- a/integration-tests/src/test/scala/za/co/absa/spline/SQLCommandsSpec.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/SQLCommandsSpec.scala
@@ -38,7 +38,7 @@ class SQLCommandsSpec extends AsyncFlatSpec
   behavior of "spark.sql()"
 
   it should "capture lineage of 'CREATE TABLE AS` - Hive" taggedAs ignoreIf(ver"$SPARK_VERSION" < ver"2.3") in
-    withRestartingSparkSession(_.enableHiveSupport) { implicit spark =>
+    withIsolatedSparkSession(_.enableHiveSupport) { implicit spark =>
       withLineageTracking { captor =>
         import spark.implicits._
 
@@ -67,7 +67,7 @@ class SQLCommandsSpec extends AsyncFlatSpec
     }
 
   it should "capture lineage of 'INSERT OVERWRITE AS` - Hive" taggedAs ignoreIf(ver"$SPARK_VERSION" < ver"2.3") in
-    withRestartingSparkSession(_.enableHiveSupport) { implicit spark =>
+    withIsolatedSparkSession(_.enableHiveSupport) { implicit spark =>
       withLineageTracking { captor =>
         import spark.implicits._
 
@@ -96,7 +96,7 @@ class SQLCommandsSpec extends AsyncFlatSpec
     }
 
   it should "capture lineage of 'INSERT OVERWRITE AS` - non-Hive" taggedAs ignoreIf(ver"$SPARK_VERSION" < ver"2.3") in
-    withRestartingSparkSession(_.enableHiveSupport) { implicit spark =>
+    withIsolatedSparkSession(_.enableHiveSupport) { implicit spark =>
       withLineageTracking { captor =>
         import spark.implicits._
 

--- a/integration-tests/src/test/scala/za/co/absa/spline/ViewAttributeLineageSpec.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/ViewAttributeLineageSpec.scala
@@ -34,7 +34,7 @@ class ViewAttributeLineageSpec
     with SplineFixture {
 
   it should "trace attribute dependencies through persistent view" in
-    withRestartingSparkSession(_.enableHiveSupport()) { implicit spark =>
+    withIsolatedSparkSession(_.enableHiveSupport()) { implicit spark =>
       withLineageTracking { captor =>
         val databaseName = s"unitTestDatabase_${this.getClass.getSimpleName}"
         withDatabase(databaseName,
@@ -71,7 +71,7 @@ class ViewAttributeLineageSpec
     }
 
   it should "trace attribute dependencies through global temp view" in
-    withRestartingSparkSession(_.enableHiveSupport()) { implicit spark =>
+    withIsolatedSparkSession(_.enableHiveSupport()) { implicit spark =>
       withLineageTracking { captor =>
         val databaseName = s"unitTestDatabase_${this.getClass.getSimpleName}"
         withDatabase(databaseName,
@@ -104,7 +104,7 @@ class ViewAttributeLineageSpec
     }
 
   it should "trace attribute dependencies through local temp view" in
-    withRestartingSparkSession(_.enableHiveSupport()) { implicit spark =>
+    withIsolatedSparkSession(_.enableHiveSupport()) { implicit spark =>
       withLineageTracking { captor =>
         val databaseName = s"unitTestDatabase_${this.getClass.getSimpleName}"
         withDatabase(databaseName,
@@ -137,7 +137,7 @@ class ViewAttributeLineageSpec
     }
 
   it should "handle read as a view child" in
-    withRestartingSparkSession(_.enableHiveSupport()) { implicit spark =>
+    withIsolatedSparkSession(_.enableHiveSupport()) { implicit spark =>
       withLineageTracking { captor =>
         for {
           (plan, _) <- captor.lineageOf {

--- a/integration-tests/src/test/scala/za/co/absa/spline/ViewAttributeLineageSpec.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/ViewAttributeLineageSpec.scala
@@ -34,46 +34,44 @@ class ViewAttributeLineageSpec
     with SplineFixture {
 
   it should "trace attribute dependencies through persistent view" in
-    withRestartingSparkContext {
-      withCustomSparkSession(_.enableHiveSupport()) { implicit spark =>
-        withLineageTracking { captor =>
-          val databaseName = s"unitTestDatabase_${this.getClass.getSimpleName}"
-          withDatabase(databaseName,
-            ("path", "(x String) USING hive", Seq("Monika", "Buba"))
-          ) {
+    withRestartingSparkSession(_.enableHiveSupport()) { implicit spark =>
+      withLineageTracking { captor =>
+        val databaseName = s"unitTestDatabase_${this.getClass.getSimpleName}"
+        withDatabase(databaseName,
+          ("path", "(x String) USING hive", Seq("Monika", "Buba"))
+        ) {
 
-            withNewSparkSession { innerSpark =>
-              innerSpark.sql(s"DROP VIEW IF EXISTS $databaseName.test_source_vw")
-              innerSpark.sql(s"CREATE VIEW $databaseName.test_source_vw AS SELECT * FROM $databaseName.path")
+          withNewSparkSession { innerSpark =>
+            innerSpark.sql(s"DROP VIEW IF EXISTS $databaseName.test_source_vw")
+            innerSpark.sql(s"CREATE VIEW $databaseName.test_source_vw AS SELECT * FROM $databaseName.path")
+          }
+
+          for {
+            (plan, _) <- captor.lineageOf {
+              spark.sql("select * from test_source_vw")
+                .write
+                .format("hive")
+                .mode("overwrite")
+                .saveAsTable("view_test_target")
             }
+          } yield {
+            implicit val walker: LineageWalker = LineageWalker(plan)
 
-            for {
-              (plan, _) <- captor.lineageOf {
-                spark.sql("select * from test_source_vw")
-                  .write
-                  .format("hive")
-                  .mode("overwrite")
-                  .saveAsTable("view_test_target")
-              }
-            } yield {
-              implicit val walker: LineageWalker = LineageWalker(plan)
+            val writeOutput = plan.operations.write.childOperation.outputAttributes
+            val outAttribute = writeOutput(0)
 
-              val writeOutput = plan.operations.write.childOperation.outputAttributes
-              val outAttribute = writeOutput(0)
+            val reads = plan.operations.reads
+            val readOutput = reads(0).outputAttributes
+            val inAttribute = readOutput(0)
 
-              val reads = plan.operations.reads
-              val readOutput = reads(0).outputAttributes
-              val inAttribute = readOutput(0)
-
-              outAttribute should dependOn(inAttribute)
-            }
+            outAttribute should dependOn(inAttribute)
           }
         }
       }
     }
 
   it should "trace attribute dependencies through global temp view" in
-    withCustomSparkSession(_.enableHiveSupport()) { implicit spark =>
+    withRestartingSparkSession(_.enableHiveSupport()) { implicit spark =>
       withLineageTracking { captor =>
         val databaseName = s"unitTestDatabase_${this.getClass.getSimpleName}"
         withDatabase(databaseName,
@@ -106,7 +104,7 @@ class ViewAttributeLineageSpec
     }
 
   it should "trace attribute dependencies through local temp view" in
-    withCustomSparkSession(_.enableHiveSupport()) { implicit spark =>
+    withRestartingSparkSession(_.enableHiveSupport()) { implicit spark =>
       withLineageTracking { captor =>
         val databaseName = s"unitTestDatabase_${this.getClass.getSimpleName}"
         withDatabase(databaseName,
@@ -139,7 +137,7 @@ class ViewAttributeLineageSpec
     }
 
   it should "handle read as a view child" in
-    withCustomSparkSession(_.enableHiveSupport()) { implicit spark =>
+    withRestartingSparkSession(_.enableHiveSupport()) { implicit spark =>
       withLineageTracking { captor =>
         for {
           (plan, _) <- captor.lineageOf {

--- a/integration-tests/src/test/scala/za/co/absa/spline/harvester/LineageHarvesterSpec.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/harvester/LineageHarvesterSpec.scala
@@ -365,7 +365,7 @@ class LineageHarvesterSpec extends AsyncFlatSpec
     }
 
   it should "support `CREATE TABLE ... AS SELECT` in Hive" taggedAs ignoreIf(ver"$SPARK_VERSION" < ver"2.3") in
-    withRestartingSparkSession(_
+    withIsolatedSparkSession(_
       .enableHiveSupport()
       .config("hive.exec.dynamic.partition.mode", "nonstrict")
     ) { implicit spark =>
@@ -427,7 +427,7 @@ class LineageHarvesterSpec extends AsyncFlatSpec
         |}
         |""".stripMargin
 
-    withRestartingSparkSession(_
+    withIsolatedSparkSession(_
       .config("spark.spline.postProcessingFilter", "userExtraMeta")
       .config("spark.spline.postProcessingFilter.userExtraMeta.rules", injectRules)
     ) { implicit spark =>

--- a/integration-tests/src/test/scala/za/co/absa/spline/harvester/SparkUnimplementedCommandsSpec.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/harvester/SparkUnimplementedCommandsSpec.scala
@@ -93,7 +93,7 @@ class SparkUnimplementedCommandsSpec extends AsyncFlatSpec
     * }}}
     */
   "Lineage for create data source table" should "be caught" in
-    withRestartingSparkSession(_
+    withIsolatedSparkSession(_
       .enableHiveSupport()
       .config("hive.exec.dynamic.partition.mode", "nonstrict")
     ) { implicit spark =>
@@ -119,7 +119,7 @@ class SparkUnimplementedCommandsSpec extends AsyncFlatSpec
     }
 
   "Lineage for create table like" should "be caught" in
-    withRestartingSparkSession(_
+    withIsolatedSparkSession(_
       .enableHiveSupport()
       .config("hive.exec.dynamic.partition.mode", "nonstrict")
     ) { implicit spark =>
@@ -139,7 +139,7 @@ class SparkUnimplementedCommandsSpec extends AsyncFlatSpec
     }
 
   "Lineage for truncate table" should "be caught" in
-    withRestartingSparkSession(_
+    withIsolatedSparkSession(_
       .enableHiveSupport()
       .config("hive.exec.dynamic.partition.mode", "nonstrict")
     ) { implicit spark =>
@@ -159,7 +159,7 @@ class SparkUnimplementedCommandsSpec extends AsyncFlatSpec
     }
 
   "Lineage for alter table add columns" should "be caught" in
-    withRestartingSparkSession(_
+    withIsolatedSparkSession(_
       .enableHiveSupport()
       .config("hive.exec.dynamic.partition.mode", "nonstrict")) { implicit spark =>
 
@@ -182,7 +182,7 @@ class SparkUnimplementedCommandsSpec extends AsyncFlatSpec
     * column name/type change not supported in spark 2.3 only comment change is supported
     */
   "Lineage for alter table change column" should "be caught" in
-    withRestartingSparkSession(_
+    withIsolatedSparkSession(_
       .enableHiveSupport()
       .config("hive.exec.dynamic.partition.mode", "nonstrict")) { implicit spark =>
 
@@ -203,7 +203,7 @@ class SparkUnimplementedCommandsSpec extends AsyncFlatSpec
     }
 
   "Lineage for alter table rename" should "be caught" in
-    withRestartingSparkSession(_
+    withIsolatedSparkSession(_
       .enableHiveSupport()
       .config("hive.exec.dynamic.partition.mode", "nonstrict")) { implicit spark =>
 
@@ -225,7 +225,7 @@ class SparkUnimplementedCommandsSpec extends AsyncFlatSpec
   private val tempDirPath = TempDirectory(prefix = "test").deleteOnExit().path
 
   "Lineage for load data" should "be caught" in
-    withRestartingSparkSession(_
+    withIsolatedSparkSession(_
       .enableHiveSupport()
       .config("hive.exec.dynamic.partition.mode", "nonstrict")) { implicit spark =>
 
@@ -253,7 +253,7 @@ class SparkUnimplementedCommandsSpec extends AsyncFlatSpec
     }
 
   "Lineage for alter table set location" should "be caught" in
-    withRestartingSparkSession(_
+    withIsolatedSparkSession(_
       .enableHiveSupport()
       .config("hive.exec.dynamic.partition.mode", "nonstrict")) { implicit spark =>
 

--- a/integration-tests/src/test/scala/za/co/absa/spline/harvester/SparkUnimplementedCommandsSpec.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/harvester/SparkUnimplementedCommandsSpec.scala
@@ -93,7 +93,7 @@ class SparkUnimplementedCommandsSpec extends AsyncFlatSpec
     * }}}
     */
   "Lineage for create data source table" should "be caught" in
-    withCustomSparkSession(_
+    withRestartingSparkSession(_
       .enableHiveSupport()
       .config("hive.exec.dynamic.partition.mode", "nonstrict")
     ) { implicit spark =>
@@ -119,7 +119,7 @@ class SparkUnimplementedCommandsSpec extends AsyncFlatSpec
     }
 
   "Lineage for create table like" should "be caught" in
-    withCustomSparkSession(_
+    withRestartingSparkSession(_
       .enableHiveSupport()
       .config("hive.exec.dynamic.partition.mode", "nonstrict")
     ) { implicit spark =>
@@ -139,7 +139,7 @@ class SparkUnimplementedCommandsSpec extends AsyncFlatSpec
     }
 
   "Lineage for truncate table" should "be caught" in
-    withCustomSparkSession(_
+    withRestartingSparkSession(_
       .enableHiveSupport()
       .config("hive.exec.dynamic.partition.mode", "nonstrict")
     ) { implicit spark =>
@@ -159,7 +159,7 @@ class SparkUnimplementedCommandsSpec extends AsyncFlatSpec
     }
 
   "Lineage for alter table add columns" should "be caught" in
-    withCustomSparkSession(_
+    withRestartingSparkSession(_
       .enableHiveSupport()
       .config("hive.exec.dynamic.partition.mode", "nonstrict")) { implicit spark =>
 
@@ -182,7 +182,7 @@ class SparkUnimplementedCommandsSpec extends AsyncFlatSpec
     * column name/type change not supported in spark 2.3 only comment change is supported
     */
   "Lineage for alter table change column" should "be caught" in
-    withCustomSparkSession(_
+    withRestartingSparkSession(_
       .enableHiveSupport()
       .config("hive.exec.dynamic.partition.mode", "nonstrict")) { implicit spark =>
 
@@ -203,7 +203,7 @@ class SparkUnimplementedCommandsSpec extends AsyncFlatSpec
     }
 
   "Lineage for alter table rename" should "be caught" in
-    withCustomSparkSession(_
+    withRestartingSparkSession(_
       .enableHiveSupport()
       .config("hive.exec.dynamic.partition.mode", "nonstrict")) { implicit spark =>
 
@@ -225,7 +225,7 @@ class SparkUnimplementedCommandsSpec extends AsyncFlatSpec
   private val tempDirPath = TempDirectory(prefix = "test").deleteOnExit().path
 
   "Lineage for load data" should "be caught" in
-    withCustomSparkSession(_
+    withRestartingSparkSession(_
       .enableHiveSupport()
       .config("hive.exec.dynamic.partition.mode", "nonstrict")) { implicit spark =>
 
@@ -253,7 +253,7 @@ class SparkUnimplementedCommandsSpec extends AsyncFlatSpec
     }
 
   "Lineage for alter table set location" should "be caught" in
-    withCustomSparkSession(_
+    withRestartingSparkSession(_
       .enableHiveSupport()
       .config("hive.exec.dynamic.partition.mode", "nonstrict")) { implicit spark =>
 

--- a/integration-tests/src/test/scala/za/co/absa/spline/harvester/dispatcher/HDFSLineageDispatcherSpec.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/harvester/dispatcher/HDFSLineageDispatcherSpec.scala
@@ -39,7 +39,7 @@ class HDFSLineageDispatcherSpec
   behavior of "HDFSLineageDispatcher"
 
   it should "save lineage file to a filesystem" taggedAs ignoreIf(ver"$SPARK_VERSION" < ver"2.3") in {
-    withRestartingSparkSession(_
+    withIsolatedSparkSession(_
       .config("spark.spline.lineageDispatcher", "hdfs")
       .config("spark.spline.lineageDispatcher.hdfs.className", classOf[HDFSLineageDispatcher].getName)
     ) { implicit spark =>

--- a/integration-tests/src/test/scala/za/co/absa/spline/harvester/dispatcher/HDFSLineageDispatcherSpec.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/harvester/dispatcher/HDFSLineageDispatcherSpec.scala
@@ -39,7 +39,7 @@ class HDFSLineageDispatcherSpec
   behavior of "HDFSLineageDispatcher"
 
   it should "save lineage file to a filesystem" taggedAs ignoreIf(ver"$SPARK_VERSION" < ver"2.3") in {
-    withCustomSparkSession(_
+    withRestartingSparkSession(_
       .config("spark.spline.lineageDispatcher", "hdfs")
       .config("spark.spline.lineageDispatcher.hdfs.className", classOf[HDFSLineageDispatcher].getName)
     ) { implicit spark =>


### PR DESCRIPTION
Merge `withCustomSparkSession()` and `withRestartingSparkContext()` into a new combined `withIsolatedSparkSession()` method

fixes #566 

**Explanation**:

The `withCustomSparkSession()` method was used to configure `SparkSession.Builder` before creating a new session.
The problem was that builder config params are stored in a shared session state that means they are still available for the subsequently created sessions even by using new builder instances. That of course implicitly affected other tests.

In order to properly isolate the session config the Spark context needs to be restarted. Which in turn means that (almost, with the exception of tests that require the same session config) every `withCustomSparkSession()` call must be wrapped with the `withRestartingSparkContext()` call.

So to simplify things a bit I have merged both methods in one.

The PR also fixes (breaks) some undesired test dependencies by using `withNewSparkSession` instead of `withSparkSession` method, that was later made unused and removed from the codebase. 

The PR also further improves Spark session isolation by generating a new temporary `metastore` and `warehouse` locations for every session returned by `SparkFixture` methods. Both locations are now kept private and all existing assertions that used them for comparison have been rewritten to only compare the meaningful part (the last part) of paths. This makes assertions more straightforward and less dependent on actual the runtime environment.