### PR TITLE
spark agent #584 quickfix of merge command on databricks

### DIFF
--- a/core/src/main/scala/za/co/absa/spline/harvester/LineageHarvester.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/LineageHarvester.scala
@@ -38,7 +38,7 @@ import za.co.absa.spline.harvester.builder.write.{WriteCommand, WriteCommandExtr
 import za.co.absa.spline.harvester.converter.DataTypeConverter
 import za.co.absa.spline.harvester.iwd.IgnoredWriteDetectionStrategy
 import za.co.absa.spline.harvester.logging.ObjectStructureLogging
-import za.co.absa.spline.harvester.plugin.embedded.DeltaPlugin.`_: MergeIntoCommand`
+import za.co.absa.spline.harvester.plugin.embedded.DeltaPlugin.{`_: MergeIntoCommandEdge`, `_: MergeIntoCommand`}
 import za.co.absa.spline.harvester.postprocessing.PostProcessor
 import za.co.absa.spline.producer.model._
 
@@ -208,6 +208,10 @@ class LineageHarvester(
         case lrdd: LogicalRDD =>
           Seq(RddWrap(lrdd.rdd))
         case `_: MergeIntoCommand`(command) =>
+          val target = extractValue[LogicalPlan](command, "target")
+          val source = extractValue[LogicalPlan](command, "source")
+          Seq(PlanWrap(source), PlanWrap(target))
+        case `_: MergeIntoCommandEdge`(command) =>
           val target = extractValue[LogicalPlan](command, "target")
           val source = extractValue[LogicalPlan](command, "source")
           Seq(PlanWrap(source), PlanWrap(target))

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/OperationNodeBuilderFactory.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/OperationNodeBuilderFactory.scala
@@ -28,7 +28,7 @@ import za.co.absa.spline.harvester.builder.rdd.read.RddReadNodeBuilder
 import za.co.absa.spline.harvester.builder.read.ReadCommand
 import za.co.absa.spline.harvester.builder.write.WriteCommand
 import za.co.absa.spline.harvester.converter.{DataConverter, DataTypeConverter}
-import za.co.absa.spline.harvester.plugin.embedded.DeltaPlugin.`_: MergeIntoCommand`
+import za.co.absa.spline.harvester.plugin.embedded.DeltaPlugin.{`_: MergeIntoCommandEdge`, `_: MergeIntoCommand`}
 import za.co.absa.spline.harvester.postprocessing.PostProcessor
 
 class OperationNodeBuilderFactory(
@@ -58,6 +58,7 @@ class OperationNodeBuilderFactory(
     case w: Window => new WindowNodeBuilder(w)(idGenerators, dataTypeConverter, dataConverter, postProcessor)
     case j: Join => new JoinNodeBuilder(j)(idGenerators, dataTypeConverter, dataConverter, postProcessor)
     case `_: MergeIntoCommand`(m) => new MergeIntoNodeBuilder(m)(idGenerators, dataTypeConverter, dataConverter, postProcessor)
+    case `_: MergeIntoCommandEdge`(m) => new MergeIntoNodeBuilder(m)(idGenerators, dataTypeConverter, dataConverter, postProcessor)
     case _ => new GenericPlanNodeBuilder(lp)(idGenerators, dataTypeConverter, dataConverter, postProcessor)
   }
 

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/MergeIntoNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/MergeIntoNodeBuilder.scala
@@ -20,7 +20,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import za.co.absa.commons.reflect.ReflectionUtils.extractValue
 import za.co.absa.spline.harvester.IdGeneratorsBundle
 import za.co.absa.spline.harvester.ModelConstants.CommonExtras
-import za.co.absa.spline.harvester.converter.{DataConverter, DataTypeConverter, OperationParamsConverter}
+import za.co.absa.spline.harvester.converter.{DataConverter, DataTypeConverter}
 import za.co.absa.spline.harvester.postprocessing.PostProcessor
 import za.co.absa.spline.producer.model.{AttrRef, Attribute, DataOperation, FunctionalExpression}
 

--- a/core/src/main/scala/za/co/absa/spline/harvester/logging/ObjectStructureDumper.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/logging/ObjectStructureDumper.scala
@@ -26,6 +26,8 @@ import scala.util.control.NonFatal
 
 object ObjectStructureDumper {
 
+  val MaxDepth = 5
+
   type FieldName = String
   type FieldType = String
   type DumpResult = String
@@ -74,6 +76,7 @@ object ObjectStructureDumper {
     prevResult: DumpResult
   ): DumpResult = stack match {
     case Nil => prevResult
+    case head :: tail if head.depth > MaxDepth => objectToStringRec(extractFieldValue)(tail, visited, prevResult)
     case head :: tail => {
       val value = head.value
       val depth = head.depth

--- a/core/src/main/scala/za/co/absa/spline/harvester/logging/ObjectStructureDumper.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/logging/ObjectStructureDumper.scala
@@ -76,7 +76,6 @@ object ObjectStructureDumper {
     prevResult: DumpResult
   ): DumpResult = stack match {
     case Nil => prevResult
-    case head :: tail if head.depth > MaxDepth => objectToStringRec(extractFieldValue)(tail, visited, prevResult)
     case head :: tail => {
       val value = head.value
       val depth = head.depth
@@ -84,6 +83,7 @@ object ObjectStructureDumper {
       val (fieldsDetails, newStack, newVisited) = value match {
         case null => ("= null", tail, visited)
         case v if isReadyForPrint(v) => (s"= $v", tail, visited)
+        case _ if head.depth >= MaxDepth => (s"! Max depth ($MaxDepth) reached", tail, visited)
         case v if wasVisited(visited, v) => ("! Object was already logged", tail, visited)
         case None => ("= None", tail, visited)
         case Some(x) => {

--- a/core/src/test/scala/za/co/absa/spline/harvester/logging/ObjectStructureDumperSpec.scala
+++ b/core/src/test/scala/za/co/absa/spline/harvester/logging/ObjectStructureDumperSpec.scala
@@ -88,6 +88,17 @@ class ObjectStructureDumperSpec extends AnyFlatSpec with Matchers with MockitoSu
     classBoxDump should not include "canonicalName"
   }
 
+  it should "not descend bellow MaxLevel" in {
+    case class AnyBox(anything: Any)
+
+    val dump = ObjectStructureDumper.dump(AnyBox(AnyBox(AnyBox(AnyBox(AnyBox(AnyBox("tooDeep")))))))
+
+    dump should include("! Max depth (5) reached")
+    dump should include("anything")
+    dump should not include "tooDeep"
+  }
+
+
   it should "ignore transient fields" in {
     class Foo {
       @transient lazy val bar = "42"


### PR DESCRIPTION
- catch Databricks class as well as Spark one
- add max depth for ObjectStructureDumper


lightly tested on Databricks:
  10.4 LTS (includes Apache Spark 3.2.1, Scala 2.12)
  11.3 LTS (includes Apache Spark 3.3.0, Scala 2.12)

fixes #584 

