### PR TITLE
spline #605 MergeIntoNodeBuilder: java.lang.IllegalArgumentException

### DIFF
--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/OperationNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/OperationNodeBuilder.scala
@@ -18,6 +18,7 @@ package za.co.absa.spline.harvester.builder
 
 import org.apache.spark.sql.catalyst.{expressions => sparkExprssions}
 import za.co.absa.spline.harvester.IdGeneratorsBundle
+import za.co.absa.spline.harvester.builder.OperationNodeBuilder.Attributes
 import za.co.absa.spline.harvester.builder.plan.PlanOperationNodeBuilder.OperationId
 import za.co.absa.spline.producer.model.{Attribute, FunctionalExpression, Literal}
 
@@ -33,10 +34,10 @@ trait OperationNodeBuilder {
   def addChild(childBuilder: OperationNodeBuilder): Unit = childBuilders :+= childBuilder
   protected def resolveAttributeChild(attribute: sparkExprssions.Attribute): Option[sparkExprssions.Expression] = None
 
-  protected def inputAttributes: Seq[Seq[Attribute]] = childBuilders.map(_.outputAttributes)
+  protected def inputAttributes: Seq[Attributes] = childBuilders.map(_.outputAttributes)
   protected def idGenerators: IdGeneratorsBundle
 
-  def outputAttributes: Seq[Attribute]
+  def outputAttributes: Attributes
 
   def childIds: Seq[OperationId] = childBuilders.map(_.operationId)
 
@@ -45,4 +46,8 @@ trait OperationNodeBuilder {
   def literals: Seq[Literal]
 
   def outputExprToAttMap: Map[sparkExprssions.ExprId, Attribute]
+}
+
+object OperationNodeBuilder {
+  type Attributes = Seq[Attribute]
 }

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/OperationNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/OperationNodeBuilder.scala
@@ -18,7 +18,7 @@ package za.co.absa.spline.harvester.builder
 
 import org.apache.spark.sql.catalyst.{expressions => sparkExprssions}
 import za.co.absa.spline.harvester.IdGeneratorsBundle
-import za.co.absa.spline.harvester.builder.OperationNodeBuilder.Attributes
+import za.co.absa.spline.harvester.builder.OperationNodeBuilder.IOAttributes
 import za.co.absa.spline.harvester.builder.plan.PlanOperationNodeBuilder.OperationId
 import za.co.absa.spline.producer.model.{Attribute, FunctionalExpression, Literal}
 
@@ -34,10 +34,10 @@ trait OperationNodeBuilder {
   def addChild(childBuilder: OperationNodeBuilder): Unit = childBuilders :+= childBuilder
   protected def resolveAttributeChild(attribute: sparkExprssions.Attribute): Option[sparkExprssions.Expression] = None
 
-  protected def inputAttributes: Seq[Attributes] = childBuilders.map(_.outputAttributes)
+  protected def inputAttributes: Seq[IOAttributes] = childBuilders.map(_.outputAttributes)
   protected def idGenerators: IdGeneratorsBundle
 
-  def outputAttributes: Attributes
+  def outputAttributes: IOAttributes
 
   def childIds: Seq[OperationId] = childBuilders.map(_.operationId)
 
@@ -49,5 +49,5 @@ trait OperationNodeBuilder {
 }
 
 object OperationNodeBuilder {
-  type Attributes = Seq[Attribute]
+  type IOAttributes = Seq[Attribute]
 }

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/GenerateNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/GenerateNodeBuilder.scala
@@ -23,8 +23,8 @@ import za.co.absa.spline.harvester.converter.{DataConverter, DataTypeConverter}
 import za.co.absa.spline.harvester.postprocessing.PostProcessor
 
 class GenerateNodeBuilder
-(override val logicalPlan: Generate)
-  (override val idGenerators: IdGeneratorsBundle, dataTypeConverter: DataTypeConverter, dataConverter: DataConverter, postProcessor: PostProcessor)
+  (logicalPlan: Generate)
+  (idGenerators: IdGeneratorsBundle, dataTypeConverter: DataTypeConverter, dataConverter: DataConverter, postProcessor: PostProcessor)
   extends GenericPlanNodeBuilder(logicalPlan)(idGenerators, dataTypeConverter, dataConverter, postProcessor) {
 
   override def resolveAttributeChild(attribute: Attribute): Option[Expression] =

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/MergeIntoNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/MergeIntoNodeBuilder.scala
@@ -33,8 +33,8 @@ class MergeIntoNodeBuilder
     val Seq(srcAttrs, trgAttrs) = inputAttributes
     val srcAttrsByName = srcAttrs.map(a => a.name -> a).toMap
     trgAttrs.map(trg => {
-      val src = srcAttrsByName.get(trg.name)
-      Seq(trg) ++ src
+      val maybeSrc = srcAttrsByName.get(trg.name)
+      Seq(trg) ++ maybeSrc
     })
   }
 

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/MergeIntoNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/MergeIntoNodeBuilder.scala
@@ -29,7 +29,14 @@ class MergeIntoNodeBuilder
   (idGenerators: IdGeneratorsBundle, dataTypeConverter: DataTypeConverter, dataConverter: DataConverter, postProcessor: PostProcessor)
   extends GenericPlanNodeBuilder(logicalPlan)(idGenerators, dataTypeConverter, dataConverter, postProcessor) {
 
-  private lazy val mergeInputs: Seq[Seq[Attribute]] = inputAttributes.transpose
+  private lazy val mergeInputs: Seq[Seq[Attribute]] = {
+    val Seq(srcAttrs, trgAttrs) = inputAttributes
+    val srcAttrsByName = srcAttrs.map(a => a.name -> a).toMap
+    trgAttrs.map(trg => {
+      val src = srcAttrsByName.get(trg.name)
+      Seq(trg) ++ src
+    })
+  }
 
   override lazy val functionalExpressions: Seq[FunctionalExpression] = Seq.empty
 

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/MergeIntoNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/MergeIntoNodeBuilder.scala
@@ -76,3 +76,27 @@ class MergeIntoNodeBuilder
     postProcessor.process(dop)
   }
 }
+
+object MergeIntoNodeBuilder {
+
+  type DeltaMergeIntoClause = SparkExpression
+  type DeltaMergeAction = SparkExpression
+
+  def extractChildren(mergeNode: LogicalPlan): Seq[LogicalPlan] = Seq(extractSource(mergeNode), extractTarget(mergeNode))
+
+  private def extractSource(mergeNode: LogicalPlan): LogicalPlan = extractValue[LogicalPlan](mergeNode, "source")
+
+  private def extractTarget(mergeNode: LogicalPlan): LogicalPlan = extractValue[LogicalPlan](mergeNode, "target")
+
+  private def extractCondition(mergeNode: LogicalPlan): SparkExpression = extractValue[SparkExpression](mergeNode, "condition")
+
+  private def extractMatchedClauses(mergeNode: LogicalPlan): Seq[DeltaMergeIntoClause] = extractValue[Seq[DeltaMergeIntoClause]](mergeNode, "matchedClauses")
+
+  private def extractNonMatchedClauses(mergeNode: LogicalPlan): Seq[DeltaMergeIntoClause] = extractValue[Seq[DeltaMergeIntoClause]](mergeNode, "notMatchedClauses")
+
+  private def extractClauseActions(clause: DeltaMergeIntoClause): Seq[DeltaMergeAction] = extractValue[Seq[DeltaMergeAction]](clause, "actions")
+
+  private def extractActionTargetAttrName(clause: DeltaMergeAction): String = extractValue[Seq[String]](clause, "targetColNameParts").head
+
+  private def extractActionSourceExpression(clause: DeltaMergeAction): SparkExpression = extractValue[SparkExpression](clause, "expr")
+}

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/MergeIntoNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/MergeIntoNodeBuilder.scala
@@ -16,50 +16,57 @@
 
 package za.co.absa.spline.harvester.builder.plan
 
+import org.apache.spark.sql.catalyst.expressions.{Expression => SparkExpression}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import za.co.absa.commons.reflect.ReflectionUtils.extractValue
 import za.co.absa.spline.harvester.IdGeneratorsBundle
 import za.co.absa.spline.harvester.ModelConstants.CommonExtras
+import za.co.absa.spline.harvester.builder.plan.MergeIntoNodeBuilder._
 import za.co.absa.spline.harvester.converter.{DataConverter, DataTypeConverter}
 import za.co.absa.spline.harvester.postprocessing.PostProcessor
-import za.co.absa.spline.producer.model.{AttrRef, Attribute, DataOperation, FunctionalExpression}
+import za.co.absa.spline.producer.model._
 
 class MergeIntoNodeBuilder
   (logicalPlan: LogicalPlan)
   (idGenerators: IdGeneratorsBundle, dataTypeConverter: DataTypeConverter, dataConverter: DataConverter, postProcessor: PostProcessor)
   extends GenericPlanNodeBuilder(logicalPlan)(idGenerators, dataTypeConverter, dataConverter, postProcessor) {
 
-  private lazy val mergeInputs: Seq[Seq[Attribute]] = {
-    val Seq(srcAttrs, trgAttrs) = inputAttributes
-    val srcAttrsByName = srcAttrs.map(a => a.name -> a).toMap
-    trgAttrs.map(trg => {
-      val maybeSrc = srcAttrsByName.get(trg.name)
-      Seq(trg) ++ maybeSrc
-    })
-  }
-
   override lazy val functionalExpressions: Seq[FunctionalExpression] = Seq.empty
 
-  override lazy val outputAttributes: Seq[Attribute] =
-    mergeInputs.map(constructMergeAttribute)
+  override lazy val outputAttributes: Seq[Attribute] = {
+    val target: LogicalPlan = extractTarget(logicalPlan)
+    val trgAttrs: Seq[Attribute] = target.output.map(attributeConverter.convert)
 
-  private def constructMergeAttribute(attributes: Seq[Attribute]) = {
-    val attr1 = attributes.head
-    val idRefs = attributes.map(a => AttrRef(a.id))
-    Attribute(
-      id = idGenerators.attributeIdGenerator.nextId(),
-      dataType = attr1.dataType,
-      childRefs = idRefs,
-      extra = Map(CommonExtras.Synthetic -> true),
-      name = attr1.name
-    )
+    val dependenciesByAttrName: Map[String, Seq[AttrOrExprRef]] =
+      (extractMatchedClauses(logicalPlan) ++ extractNonMatchedClauses(logicalPlan))
+        .flatMap(extractClauseActions)
+        .map((a: DeltaMergeAction) => {
+          val trgAttrName = extractActionTargetAttrName(a)
+          val srcExpr = extractActionSourceExpression(a)
+          trgAttrName -> exprToRefConverter.convert(srcExpr)
+        })
+        .groupBy { case (attrName, _) => attrName }
+        .mapValues(_.map({ case (_, ref) => ref }).distinct)
+
+    val outAttrs = trgAttrs.map(trgAttr => {
+      val targetRef = AttrRef(trgAttr.id)
+      val sourceRefs: Seq[AttrOrExprRef] = dependenciesByAttrName(trgAttr.name)
+      Attribute(
+        id = idGenerators.attributeIdGenerator.nextId(),
+        dataType = trgAttr.dataType,
+        childRefs = (targetRef +: sourceRefs).distinct,
+        extra = Map(CommonExtras.Synthetic -> true),
+        name = trgAttr.name
+      )
+    })
+
+    outAttrs
   }
 
   override def build(): DataOperation = {
-
-    val condition = extractValue[Any](logicalPlan, "condition").toString
-    val matchedClauses = extractValue[Seq[Any]](logicalPlan, "matchedClauses").map(_.toString)
-    val notMatchedClauses = extractValue[Seq[Any]](logicalPlan, "notMatchedClauses").map(_.toString)
+    val conditionStr = extractCondition(logicalPlan).toString
+    val matchedClausesStr = extractMatchedClauses(logicalPlan).map(_.toString)
+    val notMatchedClausesStr = extractNonMatchedClauses(logicalPlan).map(_.toString)
 
     val dop = DataOperation(
       id = operationId,
@@ -67,9 +74,9 @@ class MergeIntoNodeBuilder
       childIds = childIds,
       output = outputAttributes.map(_.id),
       params = Map(
-        "condition" -> condition,
-        "matchedClauses" -> matchedClauses,
-        "notMatchedClauses" -> notMatchedClauses),
+        "condition" -> conditionStr,
+        "matchedClauses" -> matchedClausesStr,
+        "notMatchedClauses" -> notMatchedClausesStr),
       extra = Map.empty
     )
 

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/MergeIntoNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/MergeIntoNodeBuilder.scala
@@ -25,7 +25,7 @@ import za.co.absa.spline.harvester.postprocessing.PostProcessor
 import za.co.absa.spline.producer.model.{AttrRef, Attribute, DataOperation, FunctionalExpression}
 
 class MergeIntoNodeBuilder
-(override val logicalPlan: LogicalPlan)
+  (logicalPlan: LogicalPlan)
   (idGenerators: IdGeneratorsBundle, dataTypeConverter: DataTypeConverter, dataConverter: DataConverter, postProcessor: PostProcessor)
   extends GenericPlanNodeBuilder(logicalPlan)(idGenerators, dataTypeConverter, dataConverter, postProcessor) {
 

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/MergeIntoNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/MergeIntoNodeBuilder.scala
@@ -21,6 +21,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import za.co.absa.commons.reflect.ReflectionUtils.extractValue
 import za.co.absa.spline.harvester.IdGeneratorsBundle
 import za.co.absa.spline.harvester.ModelConstants.CommonExtras
+import za.co.absa.spline.harvester.builder.OperationNodeBuilder.IOAttributes
 import za.co.absa.spline.harvester.builder.plan.MergeIntoNodeBuilder._
 import za.co.absa.spline.harvester.converter.{DataConverter, DataTypeConverter}
 import za.co.absa.spline.harvester.postprocessing.PostProcessor
@@ -33,9 +34,9 @@ class MergeIntoNodeBuilder
 
   override lazy val functionalExpressions: Seq[FunctionalExpression] = Seq.empty
 
-  override lazy val outputAttributes: Seq[Attribute] = {
+  override lazy val outputAttributes: IOAttributes = {
     val target: LogicalPlan = extractTarget(logicalPlan)
-    val trgAttrs: Seq[Attribute] = target.output.map(attributeConverter.convert)
+    val trgAttrs: IOAttributes = target.output.map(attributeConverter.convert)
 
     val dependenciesByAttrName: Map[String, Seq[AttrOrExprRef]] =
       (extractMatchedClauses(logicalPlan) ++ extractNonMatchedClauses(logicalPlan))

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/PlanOperationNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/PlanOperationNodeBuilder.scala
@@ -21,6 +21,7 @@ import org.apache.spark.sql.catalyst.{expressions => sparkExprssions}
 import za.co.absa.commons.lang.CachingConverter
 import za.co.absa.spline.harvester.IdGeneratorsBundle
 import za.co.absa.spline.harvester.builder.OperationNodeBuilder
+import za.co.absa.spline.harvester.builder.OperationNodeBuilder.IOAttributes
 import za.co.absa.spline.harvester.converter._
 import za.co.absa.spline.producer.model.{Attribute, FunctionalExpression, Literal}
 
@@ -62,7 +63,7 @@ trait PlanOperationNodeBuilder extends OperationNodeBuilder {
       literalConverter
     )
 
-  lazy val outputAttributes: Seq[Attribute] =
+  lazy val outputAttributes: IOAttributes =
     logicalPlan.output.map(attributeConverter.convert)
 
   override def outputExprToAttMap: Map[sparkExprssions.ExprId, Attribute] =
@@ -75,5 +76,4 @@ trait PlanOperationNodeBuilder extends OperationNodeBuilder {
 
 object PlanOperationNodeBuilder {
   type OperationId = String
-  type OutputAttIds = Seq[String]
 }

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/UnionNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/UnionNodeBuilder.scala
@@ -21,6 +21,7 @@ import org.apache.spark.sql.catalyst.{expressions => sparkExprssions}
 import za.co.absa.commons.lang.extensions.NonOptionExtension._
 import za.co.absa.spline.harvester.IdGeneratorsBundle
 import za.co.absa.spline.harvester.ModelConstants.CommonExtras
+import za.co.absa.spline.harvester.builder.OperationNodeBuilder.Attributes
 import za.co.absa.spline.harvester.builder.plan.UnionNodeBuilder.Names
 import za.co.absa.spline.harvester.converter.{DataConverter, DataTypeConverter}
 import za.co.absa.spline.harvester.postprocessing.PostProcessor
@@ -31,7 +32,7 @@ class UnionNodeBuilder
   (idGenerators: IdGeneratorsBundle, dataTypeConverter: DataTypeConverter, dataConverter: DataConverter, postProcessor: PostProcessor)
   extends GenericPlanNodeBuilder(logicalPlan)(idGenerators, dataTypeConverter, dataConverter, postProcessor) {
 
-  private lazy val unionInputs: Seq[Seq[Attribute]] = inputAttributes.transpose
+  private lazy val unionInputs: Seq[Attributes] = inputAttributes.transpose
 
   override lazy val functionalExpressions: Seq[FunctionalExpression] =
     unionInputs

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/UnionNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/UnionNodeBuilder.scala
@@ -27,7 +27,7 @@ import za.co.absa.spline.harvester.postprocessing.PostProcessor
 import za.co.absa.spline.producer.model.{AttrRef, Attribute, ExprRef, FunctionalExpression}
 
 class UnionNodeBuilder
-(override val logicalPlan: Union)
+  (logicalPlan: Union)
   (idGenerators: IdGeneratorsBundle, dataTypeConverter: DataTypeConverter, dataConverter: DataConverter, postProcessor: PostProcessor)
   extends GenericPlanNodeBuilder(logicalPlan)(idGenerators, dataTypeConverter, dataConverter, postProcessor) {
 

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/UnionNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/UnionNodeBuilder.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.catalyst.{expressions => sparkExprssions}
 import za.co.absa.commons.lang.extensions.NonOptionExtension._
 import za.co.absa.spline.harvester.IdGeneratorsBundle
 import za.co.absa.spline.harvester.ModelConstants.CommonExtras
-import za.co.absa.spline.harvester.builder.OperationNodeBuilder.Attributes
+import za.co.absa.spline.harvester.builder.OperationNodeBuilder.IOAttributes
 import za.co.absa.spline.harvester.builder.plan.UnionNodeBuilder.Names
 import za.co.absa.spline.harvester.converter.{DataConverter, DataTypeConverter}
 import za.co.absa.spline.harvester.postprocessing.PostProcessor
@@ -32,14 +32,14 @@ class UnionNodeBuilder
   (idGenerators: IdGeneratorsBundle, dataTypeConverter: DataTypeConverter, dataConverter: DataConverter, postProcessor: PostProcessor)
   extends GenericPlanNodeBuilder(logicalPlan)(idGenerators, dataTypeConverter, dataConverter, postProcessor) {
 
-  private lazy val unionInputs: Seq[Attributes] = inputAttributes.transpose
+  private lazy val unionInputs: Seq[IOAttributes] = inputAttributes.transpose
 
   override lazy val functionalExpressions: Seq[FunctionalExpression] =
     unionInputs
       .zip(logicalPlan.output)
       .map { case (input, output) => constructUnionFunction(input, output) }
 
-  override lazy val outputAttributes: Seq[Attribute] =
+  override lazy val outputAttributes: IOAttributes =
     unionInputs
       .zip(functionalExpressions)
       .map { case (input, function) => constructUnionAttribute(input, function) }

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/write/WriteNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/plan/write/WriteNodeBuilder.scala
@@ -27,7 +27,7 @@ import za.co.absa.spline.harvester.postprocessing.PostProcessor
 import za.co.absa.spline.producer.model.{Attribute, WriteOperation}
 
 class WriteNodeBuilder
-(command: WriteCommand)
+  (command: WriteCommand)
   (val idGenerators: IdGeneratorsBundle, val dataTypeConverter: DataTypeConverter, val dataConverter: DataConverter, postProcessor: PostProcessor)
   extends PlanOperationNodeBuilder {
 

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/rdd/RddOperationNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/rdd/RddOperationNodeBuilder.scala
@@ -18,9 +18,9 @@ package za.co.absa.spline.harvester.builder.rdd
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions.ExprId
-import za.co.absa.commons.lang.OptionImplicits.NonOptionWrapper
 import za.co.absa.spline.harvester.IdGeneratorsBundle
 import za.co.absa.spline.harvester.builder.OperationNodeBuilder
+import za.co.absa.spline.harvester.builder.OperationNodeBuilder.IOAttributes
 import za.co.absa.spline.producer.model.{Attribute, FunctionalExpression, Literal}
 
 trait RddOperationNodeBuilder extends OperationNodeBuilder {
@@ -29,7 +29,7 @@ trait RddOperationNodeBuilder extends OperationNodeBuilder {
 
   protected def idGenerators: IdGeneratorsBundle
 
-  lazy val outputAttributes: Seq[Attribute] = Seq.empty
+  lazy val outputAttributes: IOAttributes = Seq.empty
 
   override def outputExprToAttMap: Map[ExprId, Attribute] = Map.empty
 

--- a/integration-tests/src/main/scala/za/co/absa/spline/test/ProducerModelImplicits.scala
+++ b/integration-tests/src/main/scala/za/co/absa/spline/test/ProducerModelImplicits.scala
@@ -16,6 +16,7 @@
 
 package za.co.absa.spline.test
 
+import za.co.absa.spline.harvester.builder.OperationNodeBuilder.IOAttributes
 import za.co.absa.spline.producer.model._
 
 import scala.annotation.tailrec
@@ -24,7 +25,7 @@ object ProducerModelImplicits {
 
   implicit class OperationOps(val operation: Operation) extends AnyVal {
 
-    def outputAttributes(implicit walker: LineageWalker): Seq[Attribute] = {
+    def outputAttributes(implicit walker: LineageWalker): IOAttributes = {
       operation.output.map(walker.attributeById)
     }
 

--- a/integration-tests/src/test/scala/za/co/absa/spline/DeltaDSV2Spec.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/DeltaDSV2Spec.scala
@@ -309,7 +309,7 @@ class DeltaDSV2Spec extends AsyncFlatSpec
         withDatabase("testDB") {
           for {
             (_, _) <- lineageCaptor.lineageOf {
-              spark.sql("CREATE TABLE foo ( id INT, code STRING, name STRING ) USING DELTA")
+              spark.sql("CREATE TABLE foo ( id INT, code STRING, text STRING ) USING DELTA")
               spark.sql("INSERT INTO foo VALUES (1014, 'PLN', 'Warsaw'), (1002, 'FRA', 'Corte')")
             }
             (_, _) <- lineageCaptor.lineageOf {
@@ -337,9 +337,9 @@ class DeltaDSV2Spec extends AsyncFlatSpec
                   | ON dst.id = src.id
                   | WHEN MATCHED THEN
                   |   UPDATE SET
-                  |     name = src.name
+                  |     text = src.name
                   | WHEN NOT MATCHED
-                  |  THEN INSERT (id, name)
+                  |  THEN INSERT (id, text)
                   |  VALUES (src.id, src.name)
                   |""".stripMargin
               )

--- a/integration-tests/src/test/scala/za/co/absa/spline/DeltaDSV2Spec.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/DeltaDSV2Spec.scala
@@ -337,7 +337,7 @@ class DeltaDSV2Spec extends AsyncFlatSpec
                   | ON dst.id = src.id
                   | WHEN MATCHED THEN
                   |   UPDATE SET
-                  |     NAME = src.name
+                  |     name = src.name
                   | WHEN NOT MATCHED
                   |  THEN INSERT (id, name)
                   |  VALUES (src.id, src.name)

--- a/integration-tests/src/test/scala/za/co/absa/spline/ExpressionSpec.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/ExpressionSpec.scala
@@ -19,12 +19,10 @@ package za.co.absa.spline
 
 import org.apache.spark.sql.functions
 import org.apache.spark.sql.functions.{col, explode}
-import org.scalatest.OptionValues.convertOptionToValuable
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{Assertion, Succeeded}
 import za.co.absa.commons.io.TempFile
-import za.co.absa.commons.lang.extensions.NonOptionExtension._
 import za.co.absa.spline.producer.model._
 import za.co.absa.spline.test.fixture.SparkFixture
 import za.co.absa.spline.test.fixture.spline.SplineFixture


### PR DESCRIPTION
fixes #605 

- In the `MergeIntoNodeBuilder` replaced `inputAttribute.transpose` with a mapping algorithm based on attribute names. Transpose cannot be used for that purpose in this place as MERGE command can have inputs with different number of attributes.
- Updated `DeltaMergeDSV2Job` and `DeltaDSV2Spec` accordingly
- Fixed a minor bug in the `DeltaMergeDSV2Job` (missing string interpolation)