### PR TITLE
issue #616 YAML config to convert single-valued non-string properties…

### DIFF
--- a/core/src/main/resources/spline.default.yaml
+++ b/core/src/main/resources/spline.default.yaml
@@ -83,7 +83,7 @@ spline:
             producer.bootstrap.servers:
             producer.key.serializer: org.apache.kafka.common.serialization.StringSerializer
             producer.value.serializer: org.apache.kafka.common.serialization.StringSerializer
-            producer.max.in.flight.requests.per.connection: "1"
+            producer.max.in.flight.requests.per.connection: 1
             # topic name
             topic:
 

--- a/core/src/main/scala/za/co/absa/spline/harvester/conf/YAMLConfiguration.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/conf/YAMLConfiguration.scala
@@ -58,8 +58,10 @@ class YAMLConfiguration(yaml: String)
         case null => // ignore entries with `null` value
         case m: ju.Map[_, _] =>
           populateRecursively(dstKey, m.asInstanceOf[ju.Map[String, AnyRef]], dstMap)
+        case xs: ju.List[_] =>
+          dstMap.put(dstKey, xs)
         case v =>
-          dstMap.put(dstKey, v)
+          dstMap.put(dstKey, v.toString)
       }
     })
     dstMap

--- a/core/src/test/scala/za/co/absa/spline/harvester/conf/ReadOnlyConfigurationTest.scala
+++ b/core/src/test/scala/za/co/absa/spline/harvester/conf/ReadOnlyConfigurationTest.scala
@@ -25,38 +25,44 @@ trait ReadOnlyConfigurationTest extends AnyFunSuite with Matchers {
   protected val givenConf: ReadOnlyConfiguration
   protected val emptyConf: ReadOnlyConfiguration
 
-  test("testContainsKey") {
+  test("containsKey") {
     givenConf containsKey "spline.x.y" shouldBe true
     givenConf containsKey "spline.w.z" shouldBe true
     givenConf containsKey "spline.xs" shouldBe true
     givenConf containsKey "non-existent" shouldBe false
   }
 
-  test("testGetProperty") {
+  test("getProperty") {
     givenConf getProperty "spline.x.y" shouldEqual "foo"
     givenConf getProperty "spline.w.z" shouldEqual "bar"
     givenConf getProperty "spline.xs" should be(a[util.List[_]])
     givenConf getProperty "non-existent" shouldBe null
   }
 
-  test("testGetStringArray") {
+  test("getStringArray") {
     val xs: Array[String] = givenConf.getStringArray("spline.xs")
     xs should not be null
     xs should contain theSameElementsInOrderAs Seq("a", "b", "c")
   }
 
-  test("testGetList") {
+  test("getList") {
+    // multi-value property
     val xs: util.List[_] = givenConf.getList("spline.xs")
     xs should not be null
     xs should contain theSameElementsInOrderAs Seq("a", "b", "c")
+
+    // single-value property
+    val ys: util.List[_] = givenConf.getList("spline.x.y")
+    ys should not be null
+    ys should contain theSameElementsAs Seq("foo")
   }
 
-  test("testIsEmpty") {
+  test("isEmpty") {
     givenConf isEmpty() shouldBe false
     emptyConf isEmpty() shouldBe true
   }
 
-  test("testGetKeys") {
+  test("getKeys") {
     import scala.collection.JavaConverters._
     (givenConf getKeys "spline.x").asScala.toSeq should contain("spline.x.y")
     (givenConf getKeys "spline.x").asScala.toSeq shouldNot contain("spline.w.z")

--- a/core/src/test/scala/za/co/absa/spline/harvester/conf/YAMLConfigurationTest.scala
+++ b/core/src/test/scala/za/co/absa/spline/harvester/conf/YAMLConfigurationTest.scala
@@ -34,6 +34,22 @@ class YAMLConfigurationTest extends ReadOnlyConfigurationTest {
       |    - c
       |  ~: null_key
       |  null_value:
+      |
+      |  # ------------------------------
+      |  # for value type sensitive tests
+      |  # ------------------------------
+      |
+      |  decimalAsNumber: 1.2
+      |  decimalAsString: "1.2"
+      |  integerAsNumber: 42
+      |  integerAsString: "42"
+      |  booleanAsBoolean: true
+      |  booleanAsString: "true"
+      |  heterogeneousValues:
+      |    - 1.2
+      |    - 42
+      |    - true
+      |    - "foo"
       |""".stripMargin)
 
   test("null keys should be mapped to their parent") {
@@ -46,5 +62,32 @@ class YAMLConfigurationTest extends ReadOnlyConfigurationTest {
     givenConf.containsKey("spline.null_value") shouldBe false
     givenConf.getKeys("spline").asScala.toSeq shouldNot contain("spline.null_value")
     givenConf.getProperty("spline.null_value") shouldEqual null
+  }
+
+  test("get string value as String") {
+    givenConf getString "spline.x.y" shouldEqual "foo"
+    givenConf getString "spline.w.z" shouldEqual "bar"
+  }
+
+  test("get string value as another type") {
+    givenConf getDouble "spline.decimalAsString" shouldEqual 1.2d
+    givenConf getInt "spline.integerAsString" shouldEqual 42
+    givenConf getBoolean "spline.booleanAsString" shouldEqual true
+  }
+
+  test("get non-string value as String") {
+    givenConf getString "spline.decimalAsNumber" shouldEqual "1.2"
+    givenConf getString "spline.integerAsNumber" shouldEqual "42"
+    givenConf getString "spline.booleanAsBoolean" shouldEqual "true"
+  }
+
+  test("get single-valued non-string property as List") {
+    givenConf getList "spline.decimalAsNumber" should contain theSameElementsAs Seq("1.2")
+    givenConf getList "spline.integerAsNumber" should contain theSameElementsAs Seq("42")
+    givenConf getList "spline.booleanAsBoolean" should contain theSameElementsAs Seq("true")
+  }
+
+  test("get heterogeneous list") {
+    givenConf getList "spline.heterogeneousValues" should contain theSameElementsInOrderAs Seq(1.2, 42, true, "foo")
   }
 }

--- a/core/src/test/scala/za/co/absa/spline/harvester/conf/YAMLConfigurationTest.scala
+++ b/core/src/test/scala/za/co/absa/spline/harvester/conf/YAMLConfigurationTest.scala
@@ -61,7 +61,7 @@ class YAMLConfigurationTest extends ReadOnlyConfigurationTest {
   test("null values should be completely ignored") {
     givenConf.containsKey("spline.null_value") shouldBe false
     givenConf.getKeys("spline").asScala.toSeq shouldNot contain("spline.null_value")
-    givenConf.getProperty("spline.null_value") shouldEqual null
+    givenConf.getProperty("spline.null_value") shouldBe null
   }
 
   test("get string value as String") {
@@ -70,15 +70,21 @@ class YAMLConfigurationTest extends ReadOnlyConfigurationTest {
   }
 
   test("get string value as another type") {
-    givenConf getDouble "spline.decimalAsString" shouldEqual 1.2d
-    givenConf getInt "spline.integerAsString" shouldEqual 42
-    givenConf getBoolean "spline.booleanAsString" shouldEqual true
+    givenConf getDouble "spline.decimalAsString" shouldBe 1.2d
+    givenConf getInt "spline.integerAsString" shouldBe 42
+    givenConf getBoolean "spline.booleanAsString" shouldBe true
   }
 
   test("get non-string value as String") {
     givenConf getString "spline.decimalAsNumber" shouldEqual "1.2"
     givenConf getString "spline.integerAsNumber" shouldEqual "42"
     givenConf getString "spline.booleanAsBoolean" shouldEqual "true"
+  }
+
+  test("get non-string value as its own type") {
+    givenConf getDouble "spline.decimalAsNumber" shouldBe 1.2d
+    givenConf getInt "spline.integerAsNumber" shouldBe 42
+    givenConf getBoolean "spline.booleanAsBoolean" shouldBe true
   }
 
   test("get single-valued non-string property as List") {


### PR DESCRIPTION
… to String for better interoperability with other types of `Configuration`.

fixes #616 