### PR TITLE
Adding feature to include token generation for long process of spark.

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,15 @@ spline.lineageDispatcher.http.timeout.read=120000
 spline.lineageDispatcher.http.apiVersion=LATEST
 spline.lineageDispatcher.http.header.X-CUSTOM-HEADER=custom-header-value
 ```
+If the producer requires token based authentication for requests, below mentioned details must be included in configuration.
+```properties
+spline.lineageDispatcher.http.authentication.mode=enabled
+spline.lineageDispatcher.http.authentication.grantType=client_credentials
+spline.lineageDispatcher.http.authentication.clientId=clientid
+spline.lineageDispatcher.http.authentication.clientSecret=secret
+spline.lineageDispatcher.http.authentication.tokenUrl=tokenurl
+spline.lineageDispatcher.http.authentication.scope=scope
+```
 Example: Azure HTTP trigger template API key header can be set like this:
 ```properties
 spline.lineageDispatcher.http.header.X-FUNCTIONS-KEY=USER_API_KEY

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/HttpLineageDispatcher.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/HttpLineageDispatcher.scala
@@ -110,7 +110,7 @@ object HttpLineageDispatcher extends Logging {
       config.readTimeout,
       config.disableSslValidation,
       config.headers,
-      Some(config.authentication)
+      config.authentication
     )
   }
 

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/HttpLineageDispatcher.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/HttpLineageDispatcher.scala
@@ -109,7 +109,8 @@ object HttpLineageDispatcher extends Logging {
       config.connTimeout,
       config.readTimeout,
       config.disableSslValidation,
-      config.headers
+      config.headers,
+      Some(config.authentication)
     )
   }
 

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/HttpOpenLineageDispatcher.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/HttpOpenLineageDispatcher.scala
@@ -97,7 +97,7 @@ object HttpOpenLineageDispatcher extends Logging {
       config.readTimeout,
       config.disableSslValidation,
       config.headers,
-      Some(config.authentication)
+      config.authentication
     )
   }
 

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/HttpOpenLineageDispatcher.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/HttpOpenLineageDispatcher.scala
@@ -96,7 +96,8 @@ object HttpOpenLineageDispatcher extends Logging {
       config.connTimeout,
       config.readTimeout,
       config.disableSslValidation,
-      config.headers
+      config.headers,
+      Some(config.authentication)
     )
   }
 

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/HttpLineageDispatcherConfig.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/HttpLineageDispatcherConfig.scala
@@ -25,6 +25,7 @@ import za.co.absa.spline.harvester.dispatcher.httpdispatcher.HttpLineageDispatch
 import scala.concurrent.duration._
 
 object HttpLineageDispatcherConfig {
+  val AuthenticationProperty = "authentication"
   val ProducerUrlProperty = "producer.url"
   val ConnectionTimeoutMsKey = "timeout.connection"
   val ReadTimeoutMsKey = "timeout.read"
@@ -42,6 +43,7 @@ class HttpLineageDispatcherConfig(config: Configuration) {
   val readTimeout: Duration = config.getRequiredLong(ReadTimeoutMsKey).millis
   val disableSslValidation: Boolean = config.getRequiredBoolean(DisableSslValidation)
   val headers: Map[String, String] = config.subset(Header).toMap[String]
+  val authentication: Map[String, String] = config.subset(AuthenticationProperty).toMap[String]
 
   def apiVersionOption: Option[Version] = config.getOptionalString(ApiVersion).map(stringToVersion)
 

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/rest/AuthenticationFactory.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/rest/AuthenticationFactory.scala
@@ -1,0 +1,82 @@
+package za.co.absa.spline.harvester.dispatcher.httpdispatcher.rest
+
+import java.time.{Duration, Instant}
+
+import scalaj.http.{Base64, HttpRequest}
+
+import scala.collection.mutable
+
+trait Authentication {
+  def createRequest(httpRequest: HttpRequest,authentication: Map[String,String]):HttpRequest
+}
+
+case class ClientCredentialsAuthentication(authentication: Map[String, String]) extends Authentication {
+  private val tokenCache: mutable.Map[String, (String, Instant)] = mutable.Map.empty[String, (String, Instant)]
+  private val clientId: String = ""
+  private val clientSecret: String = ""
+  private val tokenUrl: String = ""
+  private val grantType: String = ""
+  private val scope: String = ""
+
+  private def isTokenExpired(expirationTime: Instant): Boolean = {
+    Instant.now().isAfter(expirationTime.minusSeconds(300) )
+  }
+
+  private def getToken(clientId: String, clientSecret: String, tokenUrl: String,scope: String): String = {
+    val cachedToken= tokenCache.get("token")
+    if (cachedToken.isDefined && !isTokenExpired(cachedToken.get._2)) {
+      // Token found in cache and not expired, return it
+      cachedToken.get._1
+    } else {
+      val resp = scalaj.http.Http(tokenUrl)
+        .postForm(Seq(
+          "grant_type" -> "client_credentials",
+          "client_id" -> clientId,
+          "client_secret" -> clientSecret,
+          "scope" -> scope))
+        .asString
+
+      val jsonResp = scala.util.parsing.json.JSON.parseFull(resp.body)
+      jsonResp match {
+        case Some(map: Map[String, Any]) =>
+          val token = map.getOrElse("access_token", "").toString
+          if (token.nonEmpty) {
+            val expirationTime = Instant.now().plus(Duration.ofSeconds(map.getOrElse("expires_in", "0").toString.toLong))
+            tokenCache.put("token", (token, expirationTime))
+          }
+          token
+        case _ =>
+          throw new RuntimeException("Failed to retrieve token from response")
+
+      }
+    }
+  }
+
+  override def createRequest(httpRequest: HttpRequest, authentication: Map[String, String]): HttpRequest ={
+    authentication.get("mode") match {
+      case Some("enabled") => {
+        if (authentication.contains("clientId") && authentication.contains("clientSecret") && authentication.contains("tokenUrl") && authentication.contains("scope")) {
+          val clientId = authentication("clientId")
+          val clientSecret = authentication("clientSecret")
+          val tokenUrl = authentication("tokenUrl")
+          val scope = authentication("scope")
+          val token = getToken(clientId, clientSecret, tokenUrl, scope)
+          httpRequest.header("Authorization", s"Bearer $token")
+        } else {
+          throw new IllegalArgumentException("Missing or wrong credentials")
+        }
+      }
+      case _ => httpRequest
+    }
+  }
+}
+
+object AuthenticationFactory {
+  def createAuthentication(authentication: Map[String, String]): Authentication = {
+    authentication("grantType") match {
+      case "client_credentials" => ClientCredentialsAuthentication(authentication)
+      case _ => throw new IllegalArgumentException("Invalid grant type.")
+    }
+  }
+}
+

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/rest/AuthenticationFactory.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/rest/AuthenticationFactory.scala
@@ -58,12 +58,10 @@ case class ClientCredentialsAuthentication(authentication: scala.collection.immu
       val jsonResp = scala.util.parsing.json.JSON.parseFull(resp.body)
       jsonResp match {
         case Some(map: scala.collection.immutable.Map[String, Any]) =>
-          val token = map.getOrElse("access_token", "").toString
-          if (token.nonEmpty) {
-            val expirationTime = Instant.now().plus(Duration.ofSeconds(map.getOrElse("expires_in", 0).toString.toLong))
-            val newToken = Token(token, expirationTime)
-            tokenCache = Some(newToken)
-          }
+          val token = map("access_token").toString
+          val expirationTime = Instant.now().plus(Duration.ofSeconds(map.getOrElse("expires_in", 0).toString.toLong))
+          val newToken = Token(token, expirationTime)
+          tokenCache = Some(newToken)
           token
         case _ =>
           throw new RuntimeException(failureMessage)

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/rest/AuthenticationFactory.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/rest/AuthenticationFactory.scala
@@ -69,7 +69,7 @@ case class ClientCredentialsAuthentication(authentication: scala.collection.immu
           throw new RuntimeException(failureMessage)
       }
     } else {
-      tokenCache.getOrElse(throw new RuntimeException(failureMessage)).tokenValue
+      tokenCache.get.tokenValue
     }
   }
 

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/rest/AuthenticationFactory.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/rest/AuthenticationFactory.scala
@@ -70,7 +70,7 @@ case class ClientCredentialsAuthentication(authentication: scala.collection.immu
           throw new RuntimeException(failureMessage)
       }
     } else {
-        cachedToken.get.tokenValue
+        cachedToken.getOrElse(throw new RuntimeException(failureMessage)).tokenValue
     }
   }
 

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/rest/AuthenticationFactory.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/rest/AuthenticationFactory.scala
@@ -29,9 +29,10 @@ case class ClientCredentialsAuthentication(authentication: scala.collection.immu
 
   private def getToken(clientId: String, clientSecret: String, tokenUrl: String,scope: String): String = {
     val cachedToken= tokenCache.get("token")
-    if (cachedToken.isDefined && !isTokenExpired(cachedToken.get.expirationTime)) {
+    val failureMessage = "Failed to retrieve token from response"
+    if (cachedToken.isDefined && !isTokenExpired(cachedToken.getOrElse(throw new IllegalArgumentException(failureMessage)).expirationTime)) {
       // Token found in cache and not expired, return it
-      cachedToken.get.tokenValue
+      cachedToken.getOrElse(throw new IllegalArgumentException(failureMessage)).tokenValue
     } else {
       val resp = scalaj.http.Http(tokenUrl)
         .postForm(Seq(
@@ -52,7 +53,7 @@ case class ClientCredentialsAuthentication(authentication: scala.collection.immu
           }
           token
         case _ =>
-          throw new RuntimeException("Failed to retrieve token from response")
+          throw new RuntimeException(failureMessage)
 
       }
     }

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/rest/AuthenticationFactory.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/rest/AuthenticationFactory.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package za.co.absa.spline.harvester.dispatcher.httpdispatcher.rest
 
 import java.time.{Duration, Instant}

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/rest/AuthenticationFactory.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/rest/AuthenticationFactory.scala
@@ -75,7 +75,7 @@ case class ClientCredentialsAuthentication(authentication: scala.collection.immu
   }
 
   override def createRequest(httpRequest: HttpRequest, authentication: scala.collection.immutable.Map[String, String]): HttpRequest = {
-        val token = getToken()
+        val token = getToken
         httpRequest.header("Authorization", s"Bearer $token")
   }
 }
@@ -88,7 +88,7 @@ object AuthenticationFactory extends Logging {
           case "enabled" => authentication("grantType") match {
                                   case "client_credentials" => ClientCredentialsAuthentication(authentication)
                                   case _ =>
-                                    logInfo(s"$authentication(\"grantType\") not implemented")
+                                    logInfo(s"$authentication('grantType') not implemented")
                                     NoAuthentication(authentication)
           }
         case _ =>

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/rest/AuthenticationFactory.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/rest/AuthenticationFactory.scala
@@ -92,9 +92,9 @@ case class ClientCredentialsAuthentication(authentication: scala.collection.immu
   }
 }
 
-object AuthenticationFactory {
+object AuthenticationFactory extends Logging {
   def createAuthentication(authentication: scala.collection.immutable.Map[String, String]): Authentication = {
-    log
+    logInfo(authentication("grantType"))
     authentication("grantType") match {
       case "client_credentials" => ClientCredentialsAuthentication(authentication)
       case _ => NoAuthentication(authentication)

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/rest/RestClient.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/rest/RestClient.scala
@@ -42,7 +42,7 @@ object RestClient extends Logging {
     readTimeout: Duration,
     disableSslValidation: Boolean,
     headers: Map[String, String],
-    authentication: Option[Map[String, String]]
+    authentication: Map[String, String]
   ): RestClient = {
 
     logDebug(s"baseURL = $baseURL")

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/rest/RestClient.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/rest/RestClient.scala
@@ -41,7 +41,8 @@ object RestClient extends Logging {
     connTimeout: Duration,
     readTimeout: Duration,
     disableSslValidation: Boolean,
-    headers: Map[String, String]
+    headers: Map[String, String],
+    authentication: Option[Map[String, String]]
   ): RestClient = {
 
     logDebug(s"baseURL = $baseURL")
@@ -67,7 +68,7 @@ object RestClient extends Logging {
           .having(maybeDisableSslValidationOption)(_ option _)
           .header(SplineHeaders.Timeout, readTimeout.toMillis.toString)
           .headers(headers)
-          .compress(true))
+          .compress(true),authentication)
     }
   }
 }

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/rest/RestClient.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/rest/RestClient.scala
@@ -50,6 +50,7 @@ object RestClient extends Logging {
     logDebug(s"readTimeout = $readTimeout")
     logDebug(s"disableSslValidation = $disableSslValidation")
     logDebug(s"headers = $headers")
+    logInfo(s"authe= $authentication")
 
     val maybeDisableSslValidationOption: Option[HttpOption] =
       if (disableSslValidation) {

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/rest/RestClient.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/rest/RestClient.scala
@@ -50,7 +50,6 @@ object RestClient extends Logging {
     logDebug(s"readTimeout = $readTimeout")
     logDebug(s"disableSslValidation = $disableSslValidation")
     logDebug(s"headers = $headers")
-    logInfo(s"authe= $authentication")
 
     val maybeDisableSslValidationOption: Option[HttpOption] =
       if (disableSslValidation) {

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/rest/RestEndpoint.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/rest/RestEndpoint.scala
@@ -17,7 +17,7 @@
 package za.co.absa.spline.harvester.dispatcher.httpdispatcher.rest
 
 import org.apache.http.HttpHeaders
-import scalaj.http.{HttpRequest, HttpResponse}
+import scalaj.http.{ HttpRequest, HttpResponse }
 import za.co.absa.commons.lang.ARM.using
 import za.co.absa.spline.harvester.dispatcher.httpdispatcher.HttpConstants.Encoding
 import za.co.absa.spline.harvester.dispatcher.httpdispatcher.rest.RestEndpoint._
@@ -25,14 +25,18 @@ import za.co.absa.spline.harvester.dispatcher.httpdispatcher.rest.RestEndpoint._
 import java.io.ByteArrayOutputStream
 import java.util.zip.GZIPOutputStream
 import javax.ws.rs.HttpMethod
+import java.time.{ Instant, Duration }
+import scala.collection.mutable
 
-class RestEndpoint(val request: HttpRequest,val authentication: Option[Map[String, String]]) {
+class RestEndpoint(val request: HttpRequest, val authentication: Map[String, String]) {
+
+  private val myCache: mutable.Map[String, (String, Instant)] = mutable.Map.empty[String, (String, Instant)]
 
   def withAuth(): HttpRequest = {
-    if(authentication.contains("clientId") && authentication.contains("clientSecret") && authentication.contains("tokenUrl") && authentication.contains("scope")) {
-      val clientId = authentication.get("clientId")
-      val clientSecret = authentication.get("clientSecret")
-      val tokenUrl = authentication.get("tokenUrl")
+    if (authentication.contains("clientId") && authentication.contains("clientSecret") && authentication.contains("tokenUrl") && authentication.contains("scope")) {
+      val clientId = authentication("clientId")
+      val clientSecret = authentication("clientSecret")
+      val tokenUrl = authentication("tokenUrl")
       val token = getToken(clientId, clientSecret, tokenUrl)
       request.header("Authorization", s"Bearer $token")
     } else {
@@ -41,20 +45,38 @@ class RestEndpoint(val request: HttpRequest,val authentication: Option[Map[Strin
   }
 
   private def getToken(clientId: String, clientSecret: String, tokenUrl: String): String = {
-    val resp = scalaj.http.Http(tokenUrl)
-      .postForm(Seq(
-        "grant_type" -> "client_credentials",
-        "client_id" -> clientId,
-        "client_secret" -> clientSecret))
-      .asString
+    val cachedToken = myCache.get("token")
+    if (cachedToken.isDefined && !isTokenExpired(cachedToken.get._2)) {
+      // Token found in cache and not expired, return it
+      cachedToken.get._1
+    } else {
+      val resp = scalaj.http.Http(tokenUrl)
+        .postForm(Seq(
+          "grant_type" -> "client_credentials",
+          "client_id" -> clientId,
+          "client_secret" -> clientSecret))
+        .asString
 
-    val jsonResp = scala.util.parsing.json.JSON.parseFull(resp.body)
-    jsonResp match {
-      case Some(map: Map[String, Any]) => map.getOrElse("access_token", "").toString
-      case _ => ""
+      val jsonResp = scala.util.parsing.json.JSON.parseFull(resp.body)
+      jsonResp match {
+        case Some(map: Map[String, Any]) =>
+          val token = map.getOrElse("access_token", "").toString
+          if (token.nonEmpty) {
+            val expirationTime = Instant.now().plus(Duration.ofSeconds(map.getOrElse("expires_in", "0").toString.toLong))
+            myCache.put("token", (token, expirationTime))
+          }
+          token
+        case _ =>
+          throw new RuntimeException("Failed to retrieve token from response")
+
+      }
     }
   }
-      
+
+  private def isTokenExpired(expirationTime: Instant): Boolean = {
+    Instant.now().isAfter(expirationTime)
+  }
+
   def head(): HttpResponse[String] = withAuth()
     .method(HttpMethod.HEAD)
     .asString

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/rest/RestEndpoint.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/rest/RestEndpoint.scala
@@ -15,6 +15,7 @@
  */
 
 package za.co.absa.spline.harvester.dispatcher.httpdispatcher.rest
+import org.apache.spark.internal.Logging
 
 import org.apache.http.HttpHeaders
 import scalaj.http.{ HttpRequest, HttpResponse }

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/rest/RestEndpoint.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/httpdispatcher/rest/RestEndpoint.scala
@@ -30,7 +30,7 @@ import scala.collection.mutable
 
 class RestEndpoint(val request: HttpRequest, val authentication: Map[String, String]) {
 
-  private val myCache: mutable.Map[String, (String, Instant)] = mutable.Map.empty[String, (String, Instant)]
+  private val tokenCache: mutable.Map[String, (String, Instant)] = mutable.Map.empty[String, (String, Instant)]
 
   def withAuth(): HttpRequest = {
     if (authentication.contains("clientId") && authentication.contains("clientSecret") && authentication.contains("tokenUrl") && authentication.contains("scope")) {
@@ -45,7 +45,7 @@ class RestEndpoint(val request: HttpRequest, val authentication: Map[String, Str
   }
 
   private def getToken(clientId: String, clientSecret: String, tokenUrl: String): String = {
-    val cachedToken = myCache.get("token")
+    val cachedToken = tokenCache.get("token")
     if (cachedToken.isDefined && !isTokenExpired(cachedToken.get._2)) {
       // Token found in cache and not expired, return it
       cachedToken.get._1
@@ -63,7 +63,7 @@ class RestEndpoint(val request: HttpRequest, val authentication: Map[String, Str
           val token = map.getOrElse("access_token", "").toString
           if (token.nonEmpty) {
             val expirationTime = Instant.now().plus(Duration.ofSeconds(map.getOrElse("expires_in", "0").toString.toLong))
-            myCache.put("token", (token, expirationTime))
+            tokenCache.put("token", (token, expirationTime))
           }
           token
         case _ =>

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/openlineage/HttpOpenLineageDispatcherConfig.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/openlineage/HttpOpenLineageDispatcherConfig.scala
@@ -31,6 +31,7 @@ object HttpOpenLineageDispatcherConfig {
   val ApiVersion = "apiVersion"
   val Namespace = "namespace"
   val Header = "header"
+  val AuthenticationProperty = "authentication"
 
   def apply(c: Configuration) = new HttpOpenLineageDispatcherConfig(c)
 }
@@ -43,4 +44,6 @@ class HttpOpenLineageDispatcherConfig(config: Configuration) {
   val apiVersion: Version = Version.asSimple(config.getRequiredString(ApiVersion))
   val namespace: String = config.getRequiredString(Namespace)
   val headers: Map[String, String] = config.subset(Header).toMap[String]
+  val authentication: Map[String, String] = config.subset(AuthenticationProperty).toMap[String]
+
 }

--- a/core/src/test/scala/za/co/absa/spline/harvester/dispatcher/HttpLineageDispatcherSpec.scala
+++ b/core/src/test/scala/za/co/absa/spline/harvester/dispatcher/HttpLineageDispatcherSpec.scala
@@ -38,8 +38,8 @@ class HttpLineageDispatcherSpec extends AnyFlatSpec with MockitoSugar {
   private val restClientMock = mock[RestClient]
   private val httpRequestMock = mock[HttpRequest]
   private val httpResponseMock = mock[HttpResponse[String]]
-
-  when(restClientMock.endpoint("status")) thenReturn new RestEndpoint(httpRequestMock)
+  private val restEndpointMock = new RestEndpoint(httpRequestMock,mock[Map[String,String]])
+  when(restClientMock.endpoint("status")) thenReturn restEndpointMock
   when(httpRequestMock.method("HEAD")) thenReturn httpRequestMock
 
   it should "not do anything when producer is ready" in {


### PR DESCRIPTION
As we have feature to add HTTP headers in the header configuration but this token expires in one hour and spline does not have a mechanism to recreate token and make requests.

This feature adds the functionality by adding a new configuration authentication, where we can specify 
* clientid, clientsecret and other details to get tokens on the fly