### PR TITLE
Bugfix/spline spark agent 723 named entity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -288,21 +288,8 @@
                                     <include>**</include>
                                 </includes>
                             </filter>
-                            <filter>
-                                <artifact>za.co.absa.commons:commons_${scala.binary.version}</artifact>
-                                <includes>
-                                    <include>**</include>
-                                </includes>
-                            </filter>
                         </filters>
                         <relocations>
-
-                            <!-- za.co.absa.commons:commons -->
-
-                            <relocation>
-                                <pattern>za.co.absa.commons</pattern>
-                                <shadedPattern>za.co.absa.spline.shaded.za.co.absa.commons</shadedPattern>
-                            </relocation>
 
                             <!-- io.github.classgraph:glassgraph -->
 


### PR DESCRIPTION
fixes #723 

- partially undo changes for #715. `za.co.absa.commons` package must not be relocated due to participation in the public API.