### PR TITLE
minor: Fix sonarcube warnings

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,1 +1,1 @@
-sonar.cpd.exclusions=/core/src/test/**/*.scala,integration-tests/src/test/**/*.scala
+sonar.cpd.exclusions=**/*Spec.*,**/*Test.*,**/*Tests.*

--- a/core/src/test/scala/za/co/absa/spline/harvester/conf/HadoopConfigurationTest.scala
+++ b/core/src/test/scala/za/co/absa/spline/harvester/conf/HadoopConfigurationTest.scala
@@ -29,5 +29,8 @@ object HadoopConfigurationTest {
   Configuration.addDefaultResource(
     s"${this.getClass.getPackage.getName.replaceAllLiterally(".", "/")}/hdfs-test-conf.xml")
 
-  def init(): Unit = {}
+  def init(): Unit = {
+    // A singleton activator.
+    // Called from the class instances to ensure execution of the companion object's constructor code.
+  }
 }

--- a/core/src/test/scala/za/co/absa/spline/harvester/postprocessing/DataSourcePasswordReplacingFilterSpec.scala
+++ b/core/src/test/scala/za/co/absa/spline/harvester/postprocessing/DataSourcePasswordReplacingFilterSpec.scala
@@ -77,12 +77,12 @@ class DataSourcePasswordReplacingFilterSpec extends AnyFlatSpec with Matchers wi
       "b" -> Seq(null),
       "c" -> None,
       "m" -> Map(
-        "url" -> "jdbc:postgresql://bob:secret@someHost:somePort/someDB",
+        "url" -> "jdbc:postgresql://bob:secret@someHost:somePort/someDB", // NOSONAR
         "dbtable" -> "someTable",
         "user" -> "someUser",
         "PASSPHRASE" -> "somePassword" // NOSONAR
       ),
-      "url" -> "jdbc:postgresql://bob:secret@someHost:somePort/someDB",
+      "url" -> "jdbc:postgresql://bob:secret@someHost:somePort/someDB", // NOSONAR
       "dbtable" -> "someTable",
       "user" -> "someUser",
       "password" -> "somePassword" // NOSONAR
@@ -92,14 +92,14 @@ class DataSourcePasswordReplacingFilterSpec extends AnyFlatSpec with Matchers wi
       "a" -> 42,
       "b" -> Seq(null),
       "c" -> None,
-      "url" -> "jdbc:postgresql://bob:*****@someHost:somePort/someDB",
+      "url" -> "jdbc:postgresql://bob:*****@someHost:somePort/someDB", // NOSONAR
       "m" -> Map(
-        "url" -> "jdbc:postgresql://bob:*****@someHost:somePort/someDB",
+        "url" -> "jdbc:postgresql://bob:*****@someHost:somePort/someDB", // NOSONAR
         "dbtable" -> "someTable",
         "user" -> "someUser",
         "PASSPHRASE" -> "*****" // NOSONAR
       ),
-      "url" -> "jdbc:postgresql://bob:*****@someHost:somePort/someDB",
+      "url" -> "jdbc:postgresql://bob:*****@someHost:somePort/someDB", // NOSONAR
       "dbtable" -> "someTable",
       "user" -> "someUser",
       "password" -> "*****" // NOSONAR

--- a/examples/src/main/scala/za/co/absa/spline/SparkApp.scala
+++ b/examples/src/main/scala/za/co/absa/spline/SparkApp.scala
@@ -47,5 +47,5 @@ abstract class SparkApp
    */
   val spark: SparkSession = sparkBuilder.getOrCreate()
 
-  protected override def _sqlContext: SQLContext = spark.sqlContext
+  protected override def _sqlContext: SQLContext = spark.sqlContext // NOSONAR
 }

--- a/integration-tests/src/main/scala/za/co/absa/spline/test/LineageWalker.scala
+++ b/integration-tests/src/main/scala/za/co/absa/spline/test/LineageWalker.scala
@@ -38,14 +38,9 @@ class LineageWalker(
 
   private def dependsOnRec(ref: AttrOrExprRef, id: String): Boolean = ref match {
     case AttrRef(attrIfd) =>
-      if (attrIfd == id) true
-      else dependsOnRec(attrMap(attrIfd).childRefs, id)
+      attrIfd == id || dependsOnRec(attrMap(attrIfd).childRefs, id)
     case ExprRef(exprId) =>
-      if (exprId == id) true
-      else {
-        if (litMap.contains("exprId")) false
-        else dependsOnRec(funMap(exprId).childRefs, id)
-      }
+      exprId == id || !litMap.contains("exprId") && dependsOnRec(funMap(exprId).childRefs, id)
   }
 
 }

--- a/integration-tests/src/main/scala/za/co/absa/spline/test/ProducerModelImplicits.scala
+++ b/integration-tests/src/main/scala/za/co/absa/spline/test/ProducerModelImplicits.scala
@@ -26,11 +26,11 @@ object ProducerModelImplicits {
   implicit class OperationOps(val operation: Operation) extends AnyVal {
 
     def outputAttributes(implicit walker: LineageWalker): IOAttributes = {
-      operation.output.map(walker.attributeById)
+      operation.output.map(walker.getAttributeById)
     }
 
     def childOperations(implicit walker: LineageWalker): Seq[Operation] = {
-      operation.childIds.map(walker.operationById)
+      operation.childIds.map(walker.getOperationById)
     }
 
     def childOperation(implicit walker: LineageWalker): Operation = {

--- a/integration-tests/src/main/scala/za/co/absa/spline/test/fixture/spline/SplineFixture.scala
+++ b/integration-tests/src/main/scala/za/co/absa/spline/test/fixture/spline/SplineFixture.scala
@@ -15,7 +15,6 @@
 
 package za.co.absa.spline.test.fixture.spline
 
-import org.apache.commons.configuration.BaseConfiguration
 import org.apache.spark.sql.SparkSession
 
 
@@ -26,8 +25,6 @@ trait SplineFixture {
 }
 
 object SplineFixture {
-  def EmptyConf = new BaseConfiguration
-
   def extractTableIdentifier(params: Map[String, Any]): Map[String, Any] =
     params
       .apply("table").asInstanceOf[Map[String, _]]

--- a/pom.xml
+++ b/pom.xml
@@ -166,8 +166,6 @@
                         <arg>-deprecation</arg>
                         <arg>-unchecked</arg>
                         <arg>-Ywarn-numeric-widen</arg>
-                        <!--<arg>-Ywarn-dead-code</arg>-->
-                        <!--<arg>-Ywarn-value-discard</arg>-->
                     </args>
                 </configuration>
                 <executions>


### PR DESCRIPTION
Fix SonarCloud warnings

1. Add missing comments for empty methods
2. Remove unused definitions and commented out code
3. Simplify boolean expressions
4. Mute false security alarms on leaked secrets (dummy passwords used in unit tests for testing password processing)
5. Mute code duplication warnings in tests