### PR TITLE
Spline oct 29414 qa

### DIFF
--- a/bundle-2.2/pom.xml
+++ b/bundle-2.2/pom.xml
@@ -21,7 +21,7 @@
     <name>Spline Spark Agent Bundle for Spark 2.2</name>
     <parent>
         <groupId>za.co.absa.spline.agent.spark</groupId>
-        <artifactId>spline-spark-agent_2.12</artifactId>
+        <artifactId>spline-spark-agent_2.11</artifactId>
         <relativePath>../pom.xml</relativePath>
         <version>2.3.0-SNAPSHOT</version>
     </parent>

--- a/bundle-2.3/pom.xml
+++ b/bundle-2.3/pom.xml
@@ -21,7 +21,7 @@
     <name>Spline Spark Agent Bundle for Spark 2.3</name>
     <parent>
         <groupId>za.co.absa.spline.agent.spark</groupId>
-        <artifactId>spline-spark-agent_2.12</artifactId>
+        <artifactId>spline-spark-agent_2.11</artifactId>
         <relativePath>../pom.xml</relativePath>
         <version>2.3.0-SNAPSHOT</version>
     </parent>

--- a/bundle-2.4/pom.xml
+++ b/bundle-2.4/pom.xml
@@ -16,12 +16,12 @@
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>spark-2.4-spline-agent-bundle_2.12</artifactId>
+    <artifactId>spark-2.4-spline-agent-bundle_2.11</artifactId>
     <packaging>jar</packaging>
     <name>Spline Spark Agent Bundle for Spark 2.4</name>
     <parent>
         <groupId>za.co.absa.spline.agent.spark</groupId>
-        <artifactId>spline-spark-agent_2.12</artifactId>
+        <artifactId>spline-spark-agent_2.11</artifactId>
         <relativePath>../pom.xml</relativePath>
         <version>2.3.0-SNAPSHOT</version>
     </parent>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -18,14 +18,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>agent-commons_2.12</artifactId>
+    <artifactId>agent-commons_2.11</artifactId>
     <packaging>jar</packaging>
 
     <name>Spline Spark Agent Commons</name>
 
     <parent>
         <groupId>za.co.absa.spline.agent.spark</groupId>
-        <artifactId>spline-spark-agent_2.12</artifactId>
+        <artifactId>spline-spark-agent_2.11</artifactId>
         <relativePath>../pom.xml</relativePath>
         <version>2.3.0-SNAPSHOT</version>
     </parent>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -18,14 +18,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>agent-core_2.12</artifactId>
+    <artifactId>agent-core_2.11</artifactId>
     <packaging>jar</packaging>
 
     <name>Spline Spark Agent Core</name>
 
     <parent>
         <groupId>za.co.absa.spline.agent.spark</groupId>
-        <artifactId>spline-spark-agent_2.12</artifactId>
+        <artifactId>spline-spark-agent_2.11</artifactId>
         <relativePath>../pom.xml</relativePath>
         <version>2.3.0-SNAPSHOT</version>
     </parent>

--- a/core/src/main/scala/za/co/absa/spline/agent/SplineAgent.scala
+++ b/core/src/main/scala/za/co/absa/spline/agent/SplineAgent.scala
@@ -70,6 +70,9 @@ object SplineAgent extends Logging {
 
     new SplineAgent {
       def handle(funcName: FuncName, qe: QueryExecution, result: Either[Throwable, Duration]): Unit = withErrorHandling {
+        // --- SIMULATED ERROR ---
+        throw new RuntimeException("Simulated Spline error for testing to ensure Spark job doesn't fail")
+
         val idGenerators = new IdGeneratorsBundle(execPlanUUIDGeneratorFactory)
         val harvestingContext = new HarvestingContext(funcName, qe.analyzed, Some(qe.executedPlan), session, idGenerators)
         val postProcessor = new PostProcessor(filters, harvestingContext)

--- a/core/src/main/scala/za/co/absa/spline/agent/SplineAgent.scala
+++ b/core/src/main/scala/za/co/absa/spline/agent/SplineAgent.scala
@@ -69,7 +69,7 @@ object SplineAgent extends Logging {
     val readCommandExtractor = new PluggableReadCommandExtractor(pluginRegistry, dataSourceFormatResolver)
 
     new SplineAgent {
-      def handle(funcName: FuncName, qe: QueryExecution, result: Either[Throwable, Duration]): Unit = withErrorHandling {
+      def handle(funcName: FuncName, qe: QueryExecution, result: Either[Throwable, Duration]): Unit = withErrorHandling() {
         val idGenerators = new IdGeneratorsBundle(execPlanUUIDGeneratorFactory)
         val harvestingContext = new HarvestingContext(funcName, qe.analyzed, Some(qe.executedPlan), session, idGenerators)
         val postProcessor = new PostProcessor(filters, harvestingContext)
@@ -91,17 +91,21 @@ object SplineAgent extends Logging {
           .harvest(result)
           .foreach({
             case (plan, event) =>
-              lineageDispatcher.send(plan)
-              lineageDispatcher.send(event)
+              withErrorHandling("execution plan dispatch") {
+                lineageDispatcher.send(plan)
+              }
+              withErrorHandling("execution event dispatch") {
+                lineageDispatcher.send(event)
+              }
           })
       }
 
-      private def withErrorHandling(body: => Unit): Unit = {
+      private def withErrorHandling(stage: String = "lineage processing")(body: => Unit): Unit = {
         try body
         catch {
           case NonFatal(e) =>
             val ctx = session.sparkContext
-            logError(s"Unexpected error occurred during lineage processing for application: ${ctx.appName} #${ctx.applicationId}", e)
+            logError(s"Unexpected error occurred during $stage for application: ${ctx.appName} #${ctx.applicationId}", e)
         }
       }
     }

--- a/core/src/main/scala/za/co/absa/spline/agent/SplineAgent.scala
+++ b/core/src/main/scala/za/co/absa/spline/agent/SplineAgent.scala
@@ -70,9 +70,6 @@ object SplineAgent extends Logging {
 
     new SplineAgent {
       def handle(funcName: FuncName, qe: QueryExecution, result: Either[Throwable, Duration]): Unit = withErrorHandling {
-        // --- SIMULATED ERROR ---
-        throw new RuntimeException("Simulated Spline error for testing to ensure Spark job doesn't fail")
-
         val idGenerators = new IdGeneratorsBundle(execPlanUUIDGeneratorFactory)
         val harvestingContext = new HarvestingContext(funcName, qe.analyzed, Some(qe.executedPlan), session, idGenerators)
         val postProcessor = new PostProcessor(filters, harvestingContext)

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/CompositeLineageDispatcher.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/CompositeLineageDispatcher.scala
@@ -44,15 +44,19 @@ class CompositeLineageDispatcher(val delegatees: Seq[LineageDispatcher], failOnE
   }
 
   private def delegate(call: LineageDispatcher => Unit): Unit = {
-    delegatees.foreach(withErrorHandling(call))
-  }
+    val failures = delegatees.flatMap { disp =>
+      try {
+        call(disp)
+        None
+      } catch {
+        case NonFatal(e) =>
+          logWarning(s"Proceeding after an error occurred in an underlying dispatcher: ${disp.getClass.getName}", e)
+          Some(e)
+      }
+    }
 
-  private def withErrorHandling(call: LineageDispatcher => Unit): LineageDispatcher => Unit = { disp =>
-    try call(disp)
-    catch {
-      case NonFatal(e) =>
-        if (failOnErrors) throw e
-        else logWarning(s"Proceeding after an error occurred in an underlying dispatcher: ${disp.getClass.getName}", e)
+    if (failOnErrors) {
+      failures.headOption.foreach(e => throw e)
     }
   }
 }

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/FallbackLineageDispatcher.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/FallbackLineageDispatcher.scala
@@ -40,7 +40,11 @@ class FallbackLineageDispatcher(primaryDispatcher: LineageDispatcher, fallbackDi
     catch {
       case e if NonFatal(e) =>
         logError("Error when sending ExecutionPlan, will try to use fallback dispatcher next", e)
-        fallbackDispatcher.send(plan)
+        try fallbackDispatcher.send(plan)
+        catch {
+          case fallbackError if NonFatal(fallbackError) =>
+            logError("Fallback dispatcher also failed when sending ExecutionPlan. Spark job result is not affected.", fallbackError)
+        }
     }
 
   override def send(event: ExecutionEvent): Unit =
@@ -48,7 +52,11 @@ class FallbackLineageDispatcher(primaryDispatcher: LineageDispatcher, fallbackDi
     catch {
       case e if NonFatal(e) =>
         logError("Error when sending ExecutionEvent, will try to use fallback dispatcher next", e)
-        fallbackDispatcher.send(event)
+        try fallbackDispatcher.send(event)
+        catch {
+          case fallbackError if NonFatal(fallbackError) =>
+            logError("Fallback dispatcher also failed when sending ExecutionEvent. Spark job result is not affected.", fallbackError)
+        }
     }
 }
 

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/HDFSLineageDispatcher.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/HDFSLineageDispatcher.scala
@@ -147,6 +147,8 @@ class HDFSLineageDispatcher(filename: String, permission: FsPermission, bufferSi
 
   /**
    * Write a single file atomically via temp-sibling + rename.
+   * The rename is retried up to [[RenameRetries]] times with a short delay to handle
+   * transient HDFS failures (e.g. a bad datanode causing a slow or failed pipeline ack).
    */
   private def writeFileAtomically(fs: FileSystem, finalPath: Path, bytes: Array[Byte]): Unit = {
     val parent = finalPath.getParent
@@ -172,10 +174,23 @@ class HDFSLineageDispatcher(filename: String, permission: FsPermission, bufferSi
     try fs.setPermission(tmpFile, permission) catch { case _: Throwable => () }
 
     logDebug(s"Renaming $tmpFile -> $finalPath (atomic on HDFS)")
-    if (!fs.rename(tmpFile, finalPath)) {
-      try fs.delete(tmpFile, false) catch { case _: Throwable => () }
-      throw new RuntimeException(s"Failed to atomically rename $tmpFile to $finalPath")
+
+    @scala.annotation.tailrec
+    def renameWithRetry(attemptsLeft: Int): Unit = {
+      if (fs.rename(tmpFile, finalPath)) {
+        logDebug(s"Rename succeeded: $tmpFile -> $finalPath")
+      } else if (attemptsLeft > 0) {
+        logWarning(s"Rename failed for $tmpFile -> $finalPath, retrying in ${RenameRetryDelayMs}ms ($attemptsLeft attempt(s) left)")
+        Thread.sleep(RenameRetryDelayMs)
+        renameWithRetry(attemptsLeft - 1)
+      } else {
+        try fs.delete(tmpFile, false) catch { case _: Throwable => () }
+        throw new RuntimeException(
+          s"Failed to atomically rename $tmpFile to $finalPath after ${RenameRetries + 1} attempt(s)")
+      }
     }
+
+    renameWithRetry(RenameRetries)
   }
 
   // Kept for compatibility: atomic-at-file-level write for a direct full path
@@ -195,6 +210,9 @@ object HDFSLineageDispatcher {
   private val FileNameKey = "fileName"
   private val FilePermissionsKey = "filePermissions"
   private val BufferSizeKey = "fileBufferSize"
+
+  private val RenameRetries = 3
+  private val RenameRetryDelayMs = 1000L
 
   /**
    * Converts string full path to Hadoop FS and Path, e.g.

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/HDFSLineageDispatcher.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/HDFSLineageDispatcher.scala
@@ -147,6 +147,8 @@ class HDFSLineageDispatcher(filename: String, permission: FsPermission, bufferSi
 
   /**
    * Write a single file atomically via temp-sibling + rename.
+   * If the final file already exists, it is removed first so repeated attempts
+   * for the same Spark application can refresh the lineage payload.
    * The rename is retried up to [[RenameRetries]] times with a short delay to handle
    * transient HDFS failures (e.g. a bad datanode causing a slow or failed pipeline ack).
    */
@@ -172,6 +174,11 @@ class HDFSLineageDispatcher(filename: String, permission: FsPermission, bufferSi
     }
 
     try fs.setPermission(tmpFile, permission) catch { case _: Throwable => () }
+
+    if (fs.exists(finalPath) && !fs.delete(finalPath, false)) {
+      try fs.delete(tmpFile, false) catch { case _: Throwable => () }
+      throw new RuntimeException(s"Failed to delete existing lineage file before rewrite: $finalPath")
+    }
 
     logDebug(s"Renaming $tmpFile -> $finalPath (atomic on HDFS)")
 

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/HDFSLineageDispatcher.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/HDFSLineageDispatcher.scala
@@ -30,17 +30,10 @@ import za.co.absa.spline.harvester.json.HarvesterJsonSerDe
 import za.co.absa.spline.producer.model.{ExecutionEvent, ExecutionPlan}
 
 import java.net.URI
+import java.nio.charset.StandardCharsets
+import java.util.UUID
 import scala.concurrent.blocking
 
-/**
- * A port of https://github.com/AbsaOSS/spline/tree/release/0.3.9/persistence/hdfs/src/main/scala/za/co/absa/spline/persistence/hdfs
- *
- * Note:
- * This class is unstable, experimental, is mostly used for debugging, with no guarantee to work properly
- * for every generic use case in a real production application.
- *
- * It is NOT thread-safe, strictly synchronous assuming a predefined order of method calls: `send(plan)` and then `send(event)`
- */
 @Experimental
 class HDFSLineageDispatcher(filename: String, permission: FsPermission, bufferSize: Int)
   extends LineageDispatcher
@@ -62,39 +55,160 @@ class HDFSLineageDispatcher(filename: String, permission: FsPermission, bufferSi
   }
 
   override def send(event: ExecutionEvent): Unit = {
-    // check state
     if (this._lastSeenPlan == null || this._lastSeenPlan.id.get != event.planId)
       throw new IllegalStateException("send(event) must be called strictly after send(plan) method with matching plan ID")
 
     try {
-      val path = s"${this._lastSeenPlan.operations.write.outputSource.stripSuffix("/")}/$filename"
+      val sparkContext = SparkContext.getOrCreate()
+
+      val lineageBaseDir = sparkContext.getConf.get(
+        "spark.spline.lineageDispatcher.hdfs.directory",
+        "file:///C:/tmp" // Default to local storage on Windows
+      )
+
+      val executionPlanID = this._lastSeenPlan.id.getOrElse("unknown_plan")
+      val executionPlanName = this._lastSeenPlan.name.replaceAll("[^a-zA-Z0-9_\\-]", "_")
+      val runID = event.extra.get("appId").map(_.toString).getOrElse("unknown_runID")
+
+      val appDir = s"$lineageBaseDir/$executionPlanName"
+      val runDir = s"$appDir/$runID"
+
+      // Best-effort cleanup of previous runs
+      cleanupOldRunFolders(appDir, runID)
+
+      val fileName = s"lineage_${executionPlanID}.json"
+
+      // Build JSON payload
       val planWithEvent = Map(
         "executionPlan" -> this._lastSeenPlan,
         "executionEvent" -> event
       )
-
       import HarvesterJsonSerDe.impl._
-      persistToHadoopFs(planWithEvent.toJson, path)
+      val content = planWithEvent.toJson
+
+      // Atomically materialize the run folder & file
+      persistRunFolderAtomically(runDir, fileName, content)
     } finally {
       this._lastSeenPlan = null
     }
   }
 
+  /**
+   * Deletes all runID folders except the current one
+   * @param appDirPath Path to the app directory
+   * @param currentRunID The current runID to keep
+   */
+  private def cleanupOldRunFolders(appDirPath: String, currentRunID: String): Unit = {
+    try {
+      val (fs, appPath) = pathStringToFsWithPath(appDirPath)
+
+      if (fs.exists(appPath) && fs.getFileStatus(appPath).isDirectory) {
+        val statuses = fs.listStatus(appPath)
+        statuses.foreach { status =>
+          if (status.isDirectory && status.getPath.getName != currentRunID) {
+            logInfo(s"Deleting old runID folder: ${status.getPath}")
+            fs.delete(status.getPath, true) // recursive delete
+          }
+        }
+      }
+    } catch {
+      case e: Exception =>
+        logWarning(s"Failed to cleanup old run folders in $appDirPath", e)
+    }
+  }
+
+  /**
+   * Atomically create a run directory with its lineage JSON file inside.
+   * Strategy:
+   *  1) Ensure parent exists (mkdirs is idempotent)
+   *  2) Create a hidden temp directory next to the target
+   *  3) Write JSON to a temp file, then rename temp file -> final name inside temp dir
+   *  4) Rename temp dir -> final run dir (atomic on HDFS)
+   */
+  private def persistRunFolderAtomically(finalRunDirStr: String, fileName: String, content: String): Unit = blocking {
+    val (fs, finalRunDir) = pathStringToFsWithPath(finalRunDirStr)
+    val parent = finalRunDir.getParent
+
+    // 1) Ensure parent exists
+    if (!fs.exists(parent)) {
+      fs.mkdirs(parent)
+      try fs.setPermission(parent, permission) catch { case _: Throwable => () }
+    }
+
+    // 2) Create temp sibling directory
+    val tmpDir = new Path(parent, s".tmp-${finalRunDir.getName}-${UUID.randomUUID().toString}")
+    var tmpDirCreated = false
+    try {
+      if (!fs.mkdirs(tmpDir)) {
+        throw new RuntimeException(s"Failed to create temp directory: $tmpDir")
+      }
+      tmpDirCreated = true
+      try fs.setPermission(tmpDir, permission) catch { case _: Throwable => () }
+
+      // 3) Write the file atomically inside the temp dir
+      val finalFileInTmp = new Path(tmpDir, fileName)
+      writeFileAtomically(fs, finalFileInTmp, content.getBytes(StandardCharsets.UTF_8))
+
+      // 4) Rename the temp dir -> final dir (atomic on HDFS)
+      if (fs.exists(finalRunDir)) {
+        throw new IllegalStateException(s"Final run directory already exists: $finalRunDir")
+      }
+      logDebug(s"Renaming $tmpDir -> $finalRunDir (atomic on HDFS)")
+      if (!fs.rename(tmpDir, finalRunDir)) {
+        throw new RuntimeException(s"Failed to atomically rename $tmpDir to $finalRunDir")
+      }
+
+      try fs.setPermission(finalRunDir, permission) catch { case _: Throwable => () }
+    } catch {
+      case e: Throwable =>
+        if (tmpDirCreated) {
+          try fs.delete(tmpDir, true) catch { case _: Throwable => () }
+        }
+        throw e
+    }
+  }
+
+  /**
+   * Write a single file atomically via temp-sibling + rename.
+   */
+  private def writeFileAtomically(fs: FileSystem, finalPath: Path, bytes: Array[Byte]): Unit = {
+    val parent = finalPath.getParent
+    if (!fs.exists(parent)) {
+      fs.mkdirs(parent)
+    }
+
+    val tmpFile = new Path(parent, s".${finalPath.getName}.tmp-${UUID.randomUUID().toString}")
+    val replication = fs.getDefaultReplication(finalPath)
+    val blockSize = fs.getDefaultBlockSize(finalPath)
+
+    logDebug(s"Creating temp file $tmpFile")
+    val out = fs.create(tmpFile, permission, true, bufferSize, replication, blockSize, null)
+    try {
+      out.write(bytes)
+      // Best-effort durability hints; on HDFS these are meaningful.
+      out.hflush()
+      out.hsync()
+    } finally {
+      out.close()
+    }
+
+    try fs.setPermission(tmpFile, permission) catch { case _: Throwable => () }
+
+    logDebug(s"Renaming $tmpFile -> $finalPath (atomic on HDFS)")
+    if (!fs.rename(tmpFile, finalPath)) {
+      try fs.delete(tmpFile, false) catch { case _: Throwable => () }
+      throw new RuntimeException(s"Failed to atomically rename $tmpFile to $finalPath")
+    }
+  }
+
+  // Kept for compatibility: atomic-at-file-level write for a direct full path
   private def persistToHadoopFs(content: String, fullLineagePath: String): Unit = blocking {
     val (fs, path) = pathStringToFsWithPath(fullLineagePath)
-    logDebug(s"Opening HadoopFs output stream to $path")
-
-    val replication = fs.getDefaultReplication(path)
-    val blockSize = fs.getDefaultBlockSize(path)
-    val outputStream = fs.create(path, permission, true, bufferSize, replication, blockSize, null)
-
-    val umask = FsPermission.getUMask(fs.getConf)
-    FsPermission.getFileDefault.applyUMask(umask)
-
-    logDebug(s"Writing lineage to $path")
-    using(outputStream) {
-      _.write(content.getBytes("UTF-8"))
+    val parentDir = path.getParent
+    if (!fs.exists(parentDir)) {
+      fs.mkdirs(parentDir)
     }
+    writeFileAtomically(fs, path, content.getBytes(StandardCharsets.UTF_8))
   }
 }
 
@@ -108,9 +222,8 @@ object HDFSLineageDispatcher {
   /**
    * Converts string full path to Hadoop FS and Path, e.g.
    * `s3://mybucket1/path/to/file` -> S3 FS + `path/to/file`
-   * `/path/on/hdfs/to/file` -> local HDFS + `/path/on/hdfs/to/file`
-   *
-   * Note, that non-local HDFS paths are not supported in this method, e.g. hdfs://nameservice123:8020/path/on/hdfs/too.
+   * `file:///path/to/file` -> local FS + `/path/to/file`
+   * `/path/on/hdfs/to/file` -> HDFS + `/path/on/hdfs/to/file`
    *
    * @param pathString path to convert to FS and relative path
    * @return FS + relative path
@@ -119,14 +232,21 @@ object HDFSLineageDispatcher {
     pathString.toSimpleS3Location match {
       case Some(s3Location) =>
         val s3Uri = new URI(s3Location.asSimpleS3LocationString) // s3://<bucket>
-        val s3Path = new Path(s"/${s3Location.path}") // /<text-file-object-path>
-
+        val s3Path = new Path(s"/${s3Location.path}")            // /<text-file-object-path>
         val fs = FileSystem.get(s3Uri, HadoopConfiguration)
         (fs, s3Path)
 
-      case None => // local hdfs location
-        val fs = FileSystem.get(HadoopConfiguration)
-        (fs, new Path(pathString))
+      case None =>
+        // Check if it's an explicit file:// URI
+        if (pathString.startsWith("file://") || pathString.startsWith("file:/")) {
+          val uri = new URI(pathString)
+          val fs = FileSystem.get(uri, HadoopConfiguration)
+          (fs, new Path(uri.getPath))
+        } else {
+          // Default HDFS location
+          val fs = FileSystem.get(HadoopConfiguration)
+          (fs, new Path(pathString))
+        }
     }
   }
 }

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/HDFSLineageDispatcher.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/HDFSLineageDispatcher.scala
@@ -33,6 +33,7 @@ import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.util.UUID
 import scala.concurrent.blocking
+import scala.util.control.NonFatal
 
 @Experimental
 class HDFSLineageDispatcher(filename: String, permission: FsPermission, bufferSize: Int)
@@ -106,13 +107,18 @@ class HDFSLineageDispatcher(filename: String, permission: FsPermission, bufferSi
         val statuses = fs.listStatus(appPath)
         statuses.foreach { status =>
           if (status.isDirectory && status.getPath.getName != currentRunID) {
-            logInfo(s"Deleting old runID folder: ${status.getPath}")
-            fs.delete(status.getPath, true) // recursive delete
+            try {
+              logInfo(s"Deleting old runID folder: ${status.getPath}")
+              fs.delete(status.getPath, true) // recursive delete
+            } catch {
+              case NonFatal(e) =>
+                logWarning(s"Failed to delete old runID folder: ${status.getPath}", e)
+            }
           }
         }
       }
     } catch {
-      case e: Exception =>
+      case NonFatal(e) =>
         logWarning(s"Failed to cleanup old run folders in $appDirPath", e)
     }
   }

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/HDFSLineageDispatcher.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/HDFSLineageDispatcher.scala
@@ -127,45 +127,16 @@ class HDFSLineageDispatcher(filename: String, permission: FsPermission, bufferSi
    */
   private def persistRunFolderAtomically(finalRunDirStr: String, fileName: String, content: String): Unit = blocking {
     val (fs, finalRunDir) = pathStringToFsWithPath(finalRunDirStr)
-    val parent = finalRunDir.getParent
 
-    // 1) Ensure parent exists
-    if (!fs.exists(parent)) {
-      fs.mkdirs(parent)
-      try fs.setPermission(parent, permission) catch { case _: Throwable => () }
-    }
-
-    // 2) Create temp sibling directory
-    val tmpDir = new Path(parent, s".tmp-${finalRunDir.getName}-${UUID.randomUUID().toString}")
-    var tmpDirCreated = false
-    try {
-      if (!fs.mkdirs(tmpDir)) {
-        throw new RuntimeException(s"Failed to create temp directory: $tmpDir")
-      }
-      tmpDirCreated = true
-      try fs.setPermission(tmpDir, permission) catch { case _: Throwable => () }
-
-      // 3) Write the file atomically inside the temp dir
-      val finalFileInTmp = new Path(tmpDir, fileName)
-      writeFileAtomically(fs, finalFileInTmp, content.getBytes(StandardCharsets.UTF_8))
-
-      // 4) Rename the temp dir -> final dir (atomic on HDFS)
-      if (fs.exists(finalRunDir)) {
-        throw new IllegalStateException(s"Final run directory already exists: $finalRunDir")
-      }
-      logDebug(s"Renaming $tmpDir -> $finalRunDir (atomic on HDFS)")
-      if (!fs.rename(tmpDir, finalRunDir)) {
-        throw new RuntimeException(s"Failed to atomically rename $tmpDir to $finalRunDir")
-      }
-
+    // Ensure final run directory exists
+    if (!fs.exists(finalRunDir)) {
+      fs.mkdirs(finalRunDir)
       try fs.setPermission(finalRunDir, permission) catch { case _: Throwable => () }
-    } catch {
-      case e: Throwable =>
-        if (tmpDirCreated) {
-          try fs.delete(tmpDir, true) catch { case _: Throwable => () }
-        }
-        throw e
     }
+
+    // Write the file atomically inside the run directory
+    val finalFileInRunDir = new Path(finalRunDir, fileName)
+    writeFileAtomically(fs, finalFileInRunDir, content.getBytes(StandardCharsets.UTF_8))
   }
 
   /**

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/HttpLineageDispatcher.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/HttpLineageDispatcher.scala
@@ -67,14 +67,32 @@ class HttpLineageDispatcher(restClient: RestClient, apiVersionOption: Option[Ver
   override def name = "Http"
 
   override def send(plan: ExecutionPlan): Unit = {
-    for (execPlanDTO <- modelMapper.toDTO(plan)) {
-      sendJson(execPlanDTO.toJson, executionPlansEndpoint)
+    try {
+      for (execPlanDTO <- modelMapper.toDTO(plan)) {
+        try sendJson(execPlanDTO.toJson, executionPlansEndpoint)
+        catch {
+          case NonFatal(e) =>
+            logError(s"Failed to send execution plan ${plan.id} over HTTP. Spark job result is not affected.", e)
+        }
+      }
+    } catch {
+      case NonFatal(e) =>
+        logError(s"Failed to convert execution plan ${plan.id} for HTTP dispatch. Spark job result is not affected.", e)
     }
   }
 
   override def send(event: ExecutionEvent): Unit = {
-    for (eventDTO <- modelMapper.toDTO(event)) {
-      sendJson(Seq(eventDTO).toJson, executionEventsEndpoint)
+    try {
+      for (eventDTO <- modelMapper.toDTO(event)) {
+        try sendJson(Seq(eventDTO).toJson, executionEventsEndpoint)
+        catch {
+          case NonFatal(e) =>
+            logError(s"Failed to send execution event for plan ${event.planId} over HTTP. Spark job result is not affected.", e)
+        }
+      }
+    } catch {
+      case NonFatal(e) =>
+        logError(s"Failed to convert execution event for plan ${event.planId} for HTTP dispatch. Spark job result is not affected.", e)
     }
   }
 

--- a/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/KafkaLineageDispatcher.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/dispatcher/KafkaLineageDispatcher.scala
@@ -27,6 +27,8 @@ import za.co.absa.spline.harvester.dispatcher.kafkadispatcher._
 import za.co.absa.spline.harvester.dispatcher.modelmapper.ModelMapper
 import za.co.absa.spline.producer.model.{ExecutionEvent, ExecutionPlan}
 
+import scala.util.control.NonFatal
+
 /**
  * KafkaLineageDispatcher is responsible for sending the lineage data to spline gateway through kafka
  */
@@ -59,14 +61,32 @@ class KafkaLineageDispatcher(
   private val modelMapper = ModelMapper.forApiVersion(apiVersion)
 
   override def send(plan: ExecutionPlan): Unit = {
-    for (planDTO <- modelMapper.toDTO(plan)) {
-      planRecordSender.send(planDTO.toJson, plan.id.get)
+    try {
+      for (planDTO <- modelMapper.toDTO(plan)) {
+        try planRecordSender.send(planDTO.toJson, plan.id.get)
+        catch {
+          case NonFatal(e) =>
+            logError(s"Failed to send execution plan ${plan.id} to Kafka. Spark job result is not affected.", e)
+        }
+      }
+    } catch {
+      case NonFatal(e) =>
+        logError(s"Failed to convert execution plan ${plan.id} for Kafka dispatch. Spark job result is not affected.", e)
     }
   }
 
   override def send(event: ExecutionEvent): Unit = {
-    for (eventDTO <- modelMapper.toDTO(event)) {
-      eventRecordSender.send(eventDTO.toJson, event.planId)
+    try {
+      for (eventDTO <- modelMapper.toDTO(event)) {
+        try eventRecordSender.send(eventDTO.toJson, event.planId)
+        catch {
+          case NonFatal(e) =>
+            logError(s"Failed to send execution event for plan ${event.planId} to Kafka. Spark job result is not affected.", e)
+        }
+      }
+    } catch {
+      case NonFatal(e) =>
+        logError(s"Failed to convert execution event for plan ${event.planId} for Kafka dispatch. Spark job result is not affected.", e)
     }
   }
 

--- a/core/src/main/scala/za/co/absa/spline/harvester/listener/SplineQueryExecutionListener.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/listener/SplineQueryExecutionListener.scala
@@ -16,10 +16,13 @@
 
 package za.co.absa.spline.harvester.listener
 
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.QueryExecution
 import org.apache.spark.sql.util.QueryExecutionListener
 import za.co.absa.spline.harvester.SparkLineageInitializer
+
+import scala.util.control.NonFatal
 
 /**
  * Spline Codeless init entry point.
@@ -27,21 +30,33 @@ import za.co.absa.spline.harvester.SparkLineageInitializer
  *
  * @see [[https://spark.apache.org/docs/latest/configuration.html#static-sql-configuration]]
  */
-class SplineQueryExecutionListener extends QueryExecutionListener {
+class SplineQueryExecutionListener extends QueryExecutionListener with Logging {
 
-  private val maybeListener: Option[QueryExecutionListener] = {
-    val sparkSession = SparkSession.getActiveSession
-      .orElse(SparkSession.getDefaultSession)
-      .getOrElse(throw new IllegalStateException("Session is unexpectedly missing. Spline cannot be initialized."))
+  private val maybeListener: Option[QueryExecutionListener] = try {
+      val sparkSession = SparkSession.getActiveSession
+        .orElse(SparkSession.getDefaultSession)
+        .getOrElse(throw new IllegalStateException("Session is unexpectedly missing. Spline cannot be initialized."))
 
-    new SparkLineageInitializer(sparkSession).createListener(isCodelessInit = true)
+      new SparkLineageInitializer(sparkSession).createListener(isCodelessInit = true)
+    } catch {
+      case NonFatal(e) =>
+        logError("Spline listener initialization failed. Spark will continue without Spline lineage tracking.", e)
+        None
   }
 
   override def onSuccess(funcName: String, qe: QueryExecution, durationNs: Long): Unit = {
-    maybeListener.foreach(_.onSuccess(funcName, qe, durationNs))
+    try maybeListener.foreach(_.onSuccess(funcName, qe, durationNs))
+    catch {
+      case NonFatal(e) =>
+        logError(s"Spline onSuccess callback failed for function '$funcName'. Spark job result is not affected.", e)
+    }
   }
 
   override def onFailure(funcName: String, qe: QueryExecution, exception: Exception): Unit = {
-    maybeListener.foreach(_.onFailure(funcName, qe, exception))
+    try maybeListener.foreach(_.onFailure(funcName, qe, exception))
+    catch {
+      case NonFatal(e) =>
+        logError(s"Spline onFailure callback failed for function '$funcName'. Original Spark failure is preserved.", e)
+    }
   }
 }

--- a/core/src/main/scala/za/co/absa/spline/harvester/plugin/embedded/DataSourceV2Plugin.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/plugin/embedded/DataSourceV2Plugin.scala
@@ -111,8 +111,26 @@ class DataSourceV2Plugin
     val catalog = extractCatalog(ctc)
     val identifier = extractValue[AnyRef](ctc, "tableName")
     val loadTableMethods = catalog.getClass.getMethods.filter(_.getName == "loadTable")
-    val table = loadTableMethods.flatMap(m => Try(m.invoke(catalog, identifier)).toOption).head
-    val sourceId = extractSourceIdFromTable(table)
+    val maybeTable = loadTableMethods.flatMap(m => Try(m.invoke(catalog, identifier)).toOption).headOption
+
+    val sourceId = maybeTable
+      .map(extractSourceIdFromTable)
+      .getOrElse {
+        // Table does not exist yet (e.g. Iceberg CTAS before table is created).
+        // Fall back to location from tableSpec if available.
+        val locationOpt = Try {
+          val tableSpec = extractValue[AnyRef](ctc, "tableSpec")
+          val locationOption = extractValue[AnyRef](tableSpec, "location")
+          extractValue[Option[String]](locationOption, "x")
+        }.toOption.flatten
+        val provider = Try {
+          val tableSpec = extractValue[AnyRef](ctc, "tableSpec")
+          val providerOption = extractValue[AnyRef](tableSpec, "provider")
+          extractValue[Option[String]](providerOption, "x")
+        }.toOption.flatten
+        val uri = locationOpt.getOrElse(identifier.toString)
+        SourceIdentifier(provider, uri)
+      }
 
     val query = extractValue[LogicalPlan](ctc, "query")
 

--- a/core/src/main/scala/za/co/absa/spline/harvester/plugin/embedded/DataSourceV2Plugin.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/plugin/embedded/DataSourceV2Plugin.scala
@@ -60,7 +60,7 @@ class DataSourceV2Plugin
 
       val tableName = extractValue[AnyRef](namedRelation, "name")
       val output = extractValue[AnyRef](namedRelation, "output")
-      val writeOptions = extractValue[Map[String, String]](writeCommand, "writeOptions")
+      val writeOptions = Try(extractValue[Map[String, String]](writeCommand, "writeOptions")).getOrElse(Map.empty)
       val isByName = extractValue[Boolean](writeCommand, IsByName)
 
       val props = Map(
@@ -99,6 +99,9 @@ class DataSourceV2Plugin
 
     case `_: OverwritePartitionsDynamic`(_) =>
       WriteNodeInfo(sourceId, SaveMode.Overwrite, query, props)
+
+    case _ =>
+      WriteNodeInfo(sourceId, SaveMode.Append, query, props)
   }
 
   private def processV2CreateTableCommand(
@@ -115,7 +118,7 @@ class DataSourceV2Plugin
 
     val partitioning = extractValue[AnyRef](ctc, "partitioning")
     val properties = Try(extractValue[Map[String, String]](ctc, "properties")).getOrElse(Map.empty)
-    val writeOptions = extractValue[Map[String, String]](ctc, "writeOptions")
+    val writeOptions = Try(extractValue[Map[String, String]](ctc, "writeOptions")).getOrElse(Map.empty)
     val props = Map(
       "table" -> Map("identifier" -> identifier.toString),
       "partitioning" -> partitioning,
@@ -169,7 +172,7 @@ class DataSourceV2Plugin
   }
 
   private def extractSourceIdFromDeltaTableV2(table: AnyRef): SourceIdentifier = {
-    val tableProps = extractValue[java.util.Map[String, String]](table, "properties")
+    val tableProps = Try(extractValue[java.util.Map[String, String]](table, "properties")).getOrElse(new java.util.HashMap[String, String]())
 
     // for org.apache.spark.sql.delta.catalog.DeltaTableV2 delta v 1.2.0+
     val maybePath = Try(ReflectionUtils.extractValue[Path](table, "path")).toOption
@@ -178,14 +181,17 @@ class DataSourceV2Plugin
       .map(p => CatalogUtils.URIToString(p.toUri))
       .getOrElse(tableProps.get("location"))
 
-    val uri =
+    val uri = if (location != null) {
       if (URI.create(location).getScheme == null) {
         s"file:$location"
       } else {
         location
       }
-    val provider = tableProps.get("provider")
-    SourceIdentifier(Some(provider), uri)
+    } else {
+      "unknown"
+    }
+    val provider = Option(tableProps.get("provider"))
+    SourceIdentifier(provider, uri)
   }
 
   private def prependFileSchemaIfMissing(uri: String): String =

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -17,14 +17,14 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>examples_2.12</artifactId>
+    <artifactId>examples_2.11</artifactId>
     <packaging>jar</packaging>
 
     <name>Spline Spark Agent Examples</name>
 
     <parent>
         <groupId>za.co.absa.spline.agent.spark</groupId>
-        <artifactId>spline-spark-agent_2.12</artifactId>
+        <artifactId>spline-spark-agent_2.11</artifactId>
         <relativePath>../pom.xml</relativePath>
         <version>2.3.0-SNAPSHOT</version>
     </parent>

--- a/examples/src/main/java/za/co/absa/spline/example/batch/JavaExampleJob_Files.java
+++ b/examples/src/main/java/za/co/absa/spline/example/batch/JavaExampleJob_Files.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2017 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.spline.example.batch;
+
+import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.SparkSession;
+import za.co.absa.spline.agent.AgentConfig;
+import za.co.absa.spline.harvester.SparkLineageInitializer;
+import za.co.absa.spline.harvester.dispatcher.HDFSLineageDispatcher;
+import za.co.absa.spline.harvester.listener.SplineQueryExecutionListener;
+
+import java.io.File;
+import java.util.Arrays;
+
+public class JavaExampleJob_Files {
+
+    public static void main(String[] args) {
+
+
+
+        final SparkSession session = SparkSession.builder()
+            .appName("java example app")
+            .master("local[*]")
+            .config("spark.driver.host", "localhost")
+            .config("spark.spline.mode", "ENABLED")  // ✅ Enable Spline
+            .config("spark.spline.lineageDispatcher", "hdfs")  // ✅ Use HDFS dispatcher
+            .config("spark.spline.lineageDispatcher.hdfs.className", "za.co.absa.spline.harvester.dispatcher.HDFSLineageDispatcher") // 🔥 Fix: Define HDFS Dispatcher
+            .config("spark.spline.lineageDispatcher.hdfs.directory", "file:///C:/spline")  // ✅ Store lineage files in local storage
+            .config("spark.spline.lineageDispatcher.hdfs.fileNamePrefix", "lineage_")  // ✅ File naming pattern
+            .getOrCreate();
+
+
+
+// Enable Spline Tracking
+        AgentConfig splineConfig = AgentConfig.builder().build();
+        SparkLineageInitializer.enableLineageTracking(session, splineConfig);
+        System.out.println("Spline Listeners: " + splineConfig.getConfigurationListeners().size());
+
+        System.out.println("Using HDFSLineageDispatcher from: " +
+            HDFSLineageDispatcher.class.getProtectionDomain().getCodeSource().getLocation());
+
+
+
+
+
+
+        System.out.println("Spline Mode: " + session.conf().get("spark.spline.mode", "NOT SET"));
+        System.out.println("Spline HDFS: " + session.conf().get("spark.spline.lineageDispatcher.hdfs.directory", "NOT SET"));
+
+
+        // Explicitly enable Spline lineage tracking
+        // This step is optional - see https://github.com/AbsaOSS/spline-spark-agent#programmatic-initialization
+
+
+
+        // Sample Spark Job
+        session.read()
+            .option("header", "true")
+            .option("inferSchema", "true")
+            .csv("data/input/batch/wikidata.csv")
+            .as("source")
+            .write()
+            .mode(SaveMode.Overwrite)
+            .csv("data/output/batch/java-sample3.csv");
+
+//        printLineageFiles("/tmp/spline");
+
+    }
+
+    private static void printLineageFiles(String directoryPath) {
+        File dir = new File(directoryPath);
+        if (dir.exists() && dir.isDirectory()) {
+            File[] files = dir.listFiles();
+            if (files != null && files.length > 0) {
+                System.out.println("✅ Lineage Files Generated:");
+                Arrays.stream(files).forEach(file -> System.out.println(" - " + file.getAbsolutePath()));
+            } else {
+                System.out.println("⚠️ No lineage files found in " + directoryPath);
+            }
+        } else {
+            System.out.println("❌ Lineage directory does not exist: " + directoryPath);
+        }
+    }
+
+
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -20,12 +20,12 @@
 
     <parent>
         <groupId>za.co.absa.spline.agent.spark</groupId>
-        <artifactId>spline-spark-agent_2.12</artifactId>
+        <artifactId>spline-spark-agent_2.11</artifactId>
         <relativePath>../pom.xml</relativePath>
         <version>2.3.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>integration-tests_2.12</artifactId>
+    <artifactId>integration-tests_2.11</artifactId>
     <packaging>jar</packaging>
 
     <name>Spline Spark Agent Integration Tests</name>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>za.co.absa.spline.agent.spark</groupId>
-    <artifactId>spline-spark-agent_2.12</artifactId>
+    <artifactId>spline-spark-agent_2.11</artifactId>
     <name>Spline Spark Agent</name>
     <description>Spline Agent for Apache Spark</description>
     <version>2.3.0-SNAPSHOT</version>
@@ -144,8 +144,8 @@
         <scala_2.12.version>2.12.17</scala_2.12.version>
 
         <!-- Controlled by `scala-cross-build` plugin -->
-        <scala.version>2.12.17</scala.version>
-        <scala.binary.version>2.12</scala.binary.version>
+        <scala.version>2.11.12</scala.version>
+        <scala.binary.version>2.11</scala.binary.version>
     </properties>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,7 @@
                 <configuration>
                     <scalaVersion>${scala.version}</scalaVersion>
                     <args>
+                        <arg>-nobootcp</arg>
                         <arg>-target:jvm-${java.version}</arg>
                         <arg>-feature</arg>
                         <arg>-deprecation</arg>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Scala 2.11 build support.
  - Added a new example Spark job that writes lineage output to local files.
  - Enhanced HDFS lineage storage with run folder organization, best-effort cleanup, atomic persistence, and configurable rename retries.

- **Bug Fixes**
  - Improved resilience of lineage initialization and callbacks so failures don’t disrupt Spark.
  - Lineage dispatch now tolerates per-item conversion and send errors across HTTP and Kafka.
  - Safer fallback behavior when primary delivery fails, and clearer error messages with the affected processing stage.
  - More tolerant data source/Delta metadata handling, including better support for `file://` locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->