### PR TITLE
issue #922 Fix lineage crash on Column.withField/dropFields

### DIFF
--- a/core/src/main/scala/za/co/absa/spline/harvester/converter/ExpressionConverter.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/converter/ExpressionConverter.scala
@@ -101,6 +101,16 @@ class ExpressionConverter(
         params = getExpressionParameters(sparkExpr)
       )
 
+    case e if UntypedExpressionClassNames(e.getClass.getSimpleName) =>
+      FunctionalExpression(
+        id = idGen.nextId(),
+        dataType = None,
+        childRefs = convertChildren(e),
+        extra = createExtra(e, ExprV1.Types.UntypedExpression),
+        name = e.prettyName,
+        params = getExpressionParameters(e)
+      )
+
     case e: sparkExprssions.Expression =>
       FunctionalExpression(
         id = idGen.nextId(),
@@ -148,6 +158,9 @@ object ExpressionConverter {
     }
 
   }
+
+  // matched by name, not type, to keep compiling against Spark < 3.1 where these classes don't exist
+  private val UntypedExpressionClassNames: Set[String] = Set("WithField", "DropField")
 
   private val IgnoredSparkExprPropNames: Set[String] = Set("children", "dataType", "nullable")
   private val IgnoredSparkExprPropTypes: Set[Class[_]] = Set(classOf[ExprId])

--- a/core/src/test/scala/za/co/absa/spline/harvester/converter/ExpressionConverterSpec.scala
+++ b/core/src/test/scala/za/co/absa/spline/harvester/converter/ExpressionConverterSpec.scala
@@ -28,7 +28,7 @@ import org.scalatest.{Inside, OneInstancePerTest}
 import org.scalatestplus.mockito.MockitoSugar
 import za.co.absa.spline.harvester.SequentialIdGenerator
 import za.co.absa.spline.model.dt
-import za.co.absa.spline.producer.model.FunctionalExpression
+import za.co.absa.spline.producer.model.{ExprRef, FunctionalExpression}
 
 import java.util.UUID
 
@@ -214,6 +214,36 @@ class ExpressionConverterSpec extends AnyFlatSpec with OneInstancePerTest with M
         fe.dataType.isDefined should be(true)
     }
   }
+
+  it should "convert WithField without accessing its data type and preserve its child reference" in {
+    val child = Literal("this is a child")
+    val childRef = ExprRef("child_id")
+    val expression = WithField(child)
+    when(exprToRefConverterMock.convert(child)).thenReturn(childRef)
+
+    inside(converter.convert(expression)) {
+      case fe: FunctionalExpression =>
+        fe.dataType shouldBe None
+        fe.extra should contain("_typeHint" -> "expr.UntypedExpression")
+        fe.childRefs shouldEqual Seq(childRef)
+    }
+
+    verify(exprToRefConverterMock).convert(child)
+    verifyNoInteractions(dtConverterMock)
+  }
+
+  it should "convert DropField without accessing its data type" in {
+    val expression = DropField()
+
+    inside(converter.convert(expression)) {
+      case fe: FunctionalExpression =>
+        fe.dataType shouldBe None
+        fe.extra should contain("_typeHint" -> "expr.UntypedExpression")
+        fe.childRefs shouldBe empty
+    }
+
+    verifyNoInteractions(dtConverterMock, exprToRefConverterMock)
+  }
 }
 
 object ExpressionConverterSpec {
@@ -251,6 +281,41 @@ object ExpressionConverterSpec {
 
   object Foo {
     val empty = new Foo("does not matter")
+  }
+
+  case class WithField(valExpr: Expression) extends Expression {
+
+    override def children: Seq[Expression] = Seq(valExpr)
+
+    override def dataType: DataType = throw new IllegalStateException(
+      "StructFieldsOperation.dataType should not be called.")
+
+    override def nullable: Boolean = throw new IllegalStateException(
+      "StructFieldsOperation.nullable should not be called.")
+
+    override def eval(input: InternalRow): Any = ()
+
+    override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = null
+
+    protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): Expression =
+      copy(valExpr = newChildren.head)
+  }
+
+  case class DropField() extends Expression {
+
+    override def children: Seq[Expression] = Seq.empty
+
+    override def dataType: DataType = throw new IllegalStateException(
+      "StructFieldsOperation.dataType should not be called.")
+
+    override def nullable: Boolean = throw new IllegalStateException(
+      "StructFieldsOperation.nullable should not be called.")
+
+    override def eval(input: InternalRow): Any = ()
+
+    override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = null
+
+    protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): Expression = this
   }
 
   object Bar {


### PR DESCRIPTION
Fixes #922

Column.withField(...) / dropFields(...) create WithField/DropField expressions, which are children of UpdateFields (Spark 3.1+). 
Spark leaves dataType unimplemented on these two on purpose, only UpdateFields folds them to get the real result type. ExpressionConverter.convert calls .dataType on every expression node without exception, so it hits this guard and throws whenever a job uses withField/dropFields.

Since SplineAgent swallows the exception, the job itself finishes fine but lineage for that execution is dropped entirely, which is worse than an error because it just fails silently.

I didn't match on the type directly (case _: StructFieldsOperation) like the existing WindowSpecDefinition/WindowFrame case does, because StructFieldsOperation and its subtypes don't exist before Spark 3.1, and core compiles as one source tree against spark-2.2 ~ spark-3.5 profiles. So matched by class name instead (e.getClass.getSimpleName), this way it still compiles on the older profiles too.

Added two unit tests in ExpressionConverterSpec for WithField/DropField, checking dataType stays None and dtConverter is never called.

Tested locally on spark-3.4 profile, all existing tests plus the 2 new ones pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Spark field-manipulation expressions, including `WithField` and `DropField`.
  * These expressions are now recorded as untyped while preserving applicable child-expression references, improving compatibility across Spark versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->