### PR TITLE
Fix CVE-2026-54512: shade patched jackson-databind into agent-core

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -42,6 +42,15 @@
 
         <spark.version>${spark-24.version}</spark.version>
         <cassandra-connector.version>${cassandra-connector-24.version}</cassandra-connector.version>
+
+        <!--
+            Jackson is shaded into this module (see maven-shade-plugin below) so that the agent
+            is independent of whatever Jackson version the host Spark cluster provides.
+            Must stay on a line that is patched for CVE-2026-54512 et al. (2.18.8+, 2.21.4+).
+        -->
+
+        <jackson.version>2.18.10</jackson.version>
+        <paranamer.version>2.8</paranamer.version>
     </properties>
 
     <dependencies>
@@ -91,17 +100,35 @@
             <version>1.33</version>
         </dependency>
 
-        <!-- dependencies shaded by us-->
+        <!--
+            Dependencies shaded by us (relocated by maven-shade-plugin below).
+            Keep this list in sync with the <artifactSet> of the shade plugin configuration.
+        -->
 
         <dependency>
-            <groupId>za.co.absa.shaded</groupId>
-            <artifactId>absa-shaded-jackson</artifactId>
-            <version>0.0.1</version>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
-            <groupId>za.co.absa.shaded</groupId>
-            <artifactId>absa-shaded-jackson-module-scala_${scala.binary.version}</artifactId>
-            <version>0.0.2</version>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-scala_${scala.binary.version}</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.thoughtworks.paranamer</groupId>
+            <artifactId>paranamer</artifactId>
+            <version>${paranamer.version}</version>
         </dependency>
 
         <!-- optional dependencies (for plugins) -->
@@ -260,6 +287,83 @@
             <plugin>
                 <groupId>com.github.cerveada</groupId>
                 <artifactId>scalatest-maven-plugin</artifactId>
+            </plugin>
+
+            <!--
+                Shade and relocate Jackson into this module.
+
+                The agent runs inside a host Spark JVM whose own Jackson version varies wildly
+                (2.6.7 on Spark 2.4 through 2.15.2 on Spark 3.5). Relocating our copy keeps the
+                agent's JSON serde independent of the host classpath, and - unlike consuming a
+                pre-shaded third-party artifact - it lets us patch Jackson ourselves.
+
+                `combine.self="override"` is required: the parent pluginManagement configures this
+                same plugin for the *bundle* modules (minimizeJar + unrelated relocations), and
+                none of that should apply here.
+            -->
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration combine.self="override">
+                    <!-- Consumers must not resolve un-relocated Jackson transitively -->
+                    <createDependencyReducedPom>true</createDependencyReducedPom>
+                    <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+                    <useDependencyReducedPomInJar>true</useDependencyReducedPomInJar>
+                    <minimizeJar>false</minimizeJar>
+                    <shadedArtifactAttached>false</shadedArtifactAttached>
+                    <artifactSet>
+                        <includes>
+                            <include>com.fasterxml.jackson.core:jackson-annotations</include>
+                            <include>com.fasterxml.jackson.core:jackson-core</include>
+                            <include>com.fasterxml.jackson.core:jackson-databind</include>
+                            <include>com.fasterxml.jackson.module:jackson-module-scala_*</include>
+                            <include>com.thoughtworks.paranamer:paranamer</include>
+                        </includes>
+                    </artifactSet>
+                    <relocations>
+                        <relocation>
+                            <pattern>com.fasterxml.jackson</pattern>
+                            <shadedPattern>za.co.absa.spline.shaded.com.fasterxml.jackson</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>com.thoughtworks.paranamer</pattern>
+                            <shadedPattern>za.co.absa.spline.shaded.com.thoughtworks.paranamer</shadedPattern>
+                        </relocation>
+                    </relocations>
+                    <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                    </transformers>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                                <exclude>module-info.class</exclude>
+                                <!--
+                                    Drop the multi-release overlay. jackson-core ships
+                                    META-INF/versions/21/** compiled to class file major version 65,
+                                    which the shade plugin's ASM cannot read - and the bundle modules
+                                    re-shade this jar with the same plugin, so leaving it in breaks
+                                    all nine bundle builds too. The Java 8 base classes are complete;
+                                    the overlay only carries FastDoubleParser optimisations and
+                                    module-info descriptors, neither of which the agent needs.
+                                -->
+                                <exclude>META-INF/versions/**</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/core/src/main/scala/za/co/absa/spline/harvester/json/HarvesterJsonSerDe.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/json/HarvesterJsonSerDe.scala
@@ -17,11 +17,11 @@
 package za.co.absa.spline.harvester.json
 
 
-import za.co.absa.shaded.jackson.annotation.JsonInclude
-import za.co.absa.shaded.jackson.core.JsonGenerator
-import za.co.absa.shaded.jackson.core.util.{DefaultIndenter, DefaultPrettyPrinter}
-import za.co.absa.shaded.jackson.databind.{ObjectMapper, SerializationFeature}
-import za.co.absa.shaded.jackson.module.scala.DefaultScalaModule
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.core.util.{DefaultIndenter, DefaultPrettyPrinter}
+import com.fasterxml.jackson.databind.{ObjectMapper, SerializationFeature}
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
 
 object HarvesterJsonSerDe {
 


### PR DESCRIPTION
By default, Spline Spark Agent code repo shipped jackson-databind 2.15.1 inside the third-party artifact za.co.absa.shaded:absa-shaded-jackson:0.0.1. That version is within the range affected by CVE-2026-54512 (CVSS 8.1, PolymorphicTypeValidator bypass via generic type parameters) and its siblings CVE-2026-54513..54518.

Because the classes are relocated to za.co.absa.shaded.jackson, the host Spark cluster's own Jackson cannot override them - the agent carried its own vulnerable copy into every bundle from Spark 2.2 through 3.5.

absa-shaded-jackson has only ever published 0.0.1, so there was no version to bump and no <jackson.version> property in this repo to change. This commit takes ownership of the Jackson version instead: agent-core now depends on vanilla Jackson and relocates it itself via maven-shade-plugin, using the za.co.absa.spline.shaded.* prefix already used for classgraph, fastparse and java-uuid-generator.

Jackson is bumped 2.15.1 -> 2.18.10. Note that 2.19.x and 2.20.x are NOT patched for this CVE cluster; the fixes landed only in 2.18.8+, 2.21.4+ and 3.1.4. 2.18.10 is the newest of the patched 2.18 line, keeps the Java 8 baseline this project requires, and publishes both _2.11 and _2.12 artifacts.

Changes:
* core/pom.xml: replace absa-shaded-jackson / absa-shaded-jackson-module-scala with com.fasterxml.jackson.* behind a new <jackson.version> property, so any future CVE is a one-line change.
* core/pom.xml: add maven-shade-plugin relocating com.fasterxml.jackson and com.thoughtworks.paranamer. combine.self="override" is required so the module does not inherit the bundle-oriented shade config from the parent pom. META-INF/versions/** is excluded because jackson-core 2.18 ships a multi-release overlay compiled to class file major version 65, which maven-shade-plugin 3.4.1 cannot read - it fails the core build and would fail all nine bundle builds that re-shade this jar.
* HarvesterJsonSerDe.scala: imports back to vanilla com.fasterxml.jackson.*. Shading rewrites the bytecode at package time, so no behaviour changes.

No bundle POM needed changing - all nine inherit the fix through agent-core.

Verified on every bundle (Spark 2.2, 2.3, 2.4, 3.0, 3.1, 3.2, 3.3, 3.4, 3.5, across Scala 2.11 and 2.12): each jar carries the relocated Jackson at 2.18.10 and zero un-relocated jackson-databind/jackson-core classes. agent-core's dependency-reduced POM lists no com.fasterxml.jackson coordinate, so standalone --packages agent-core users cannot resolve vulnerable Jackson transitively either.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON serialization and deserialization reliability.
  * Enhanced compatibility with supported runtime environments and library versions.
  * No changes to existing JSON behavior or public functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->